### PR TITLE
Add Nix flake dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.direnv/
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "aceteam-aep development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.uv
+            pkgs.python312
+          ];
+
+          shellHook = ''
+            export UV_PYTHON="${pkgs.python312}/bin/python3"
+            export UV_PYTHON_PREFERENCE="only-system"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- Adds `flake.nix` with a devShell providing `uv` + `python312`
- Adds `flake.lock` pinning nixpkgs-unstable (2026-02-23)
- Adds `.envrc` for direnv integration (`use flake`)
- Updates `.gitignore` with `.direnv/`, `result`, `result-*`

## Usage
```sh
nix develop          # enter devShell
uv sync --extra dev  # install Python deps
uv run pytest        # run tests
```

> Note: `.envrc` requires [nix-direnv](https://github.com/nix-community/nix-direnv) for `use flake` support.

## Test plan
- [ ] `nix flake check` passes
- [ ] `nix develop` drops into a shell with `uv` and `python3.12` on PATH
- [ ] `uv sync --extra dev && uv run pytest` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)