### PR TITLE
Add Ollama and Cohere embedding clients

### DIFF
--- a/src/aceteam_aep/__init__.py
+++ b/src/aceteam_aep/__init__.py
@@ -4,7 +4,7 @@ from .agent import run_agent_loop, run_agent_loop_stream
 from .budget import BudgetEnforcer, BudgetExceededError, BudgetState, ReservationToken
 from .client import ChatClient
 from .costs import MODEL_COSTS, CostNode, CostTracker
-from .embeddings import EmbeddingClient, OpenAIEmbeddings
+from .embeddings import CohereEmbeddings, EmbeddingClient, OllamaEmbeddings, OpenAIEmbeddings
 from .envelope import Citation, ExecutionEnvelope, ExecutionError
 from .factory import create_client
 from .prompt import wrap_context, wrap_examples, wrap_file, wrap_xml
@@ -41,7 +41,9 @@ __all__ = [
     "CostTracker",
     "MODEL_COSTS",
     # Embeddings
+    "CohereEmbeddings",
     "EmbeddingClient",
+    "OllamaEmbeddings",
     "OpenAIEmbeddings",
     # Envelope
     "Citation",

--- a/src/aceteam_aep/embeddings.py
+++ b/src/aceteam_aep/embeddings.py
@@ -1,7 +1,12 @@
-"""Embeddings protocol and OpenAI implementation."""
+"""Embeddings protocol and implementations.
+
+Provides OpenAI, Ollama, and Cohere embedding clients that all
+satisfy the ``EmbeddingClient`` protocol.
+"""
 
 from __future__ import annotations
 
+import os
 from typing import Protocol, runtime_checkable
 
 import openai
@@ -52,4 +57,82 @@ class OpenAIEmbeddings:
         return result[0]
 
 
-__all__ = ["EmbeddingClient", "OpenAIEmbeddings"]
+class OllamaEmbeddings:
+    """Ollama embeddings using the ``ollama`` Python SDK."""
+
+    def __init__(
+        self,
+        model: str = "nomic-embed-text",
+        base_url: str | None = None,
+    ) -> None:
+        try:
+            import ollama as _ollama  # noqa: PLC0415
+        except ImportError as exc:
+            raise ImportError(
+                "The 'ollama' package is required for OllamaEmbeddings. "
+                "Install with: pip install ollama"
+            ) from exc
+
+        self._client = _ollama.AsyncClient(host=base_url or "http://localhost:11434")
+        self._model = model
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for a list of texts."""
+        results: list[list[float]] = []
+        for text in texts:
+            resp = await self._client.embed(model=self._model, input=text)
+            results.append(resp["embeddings"][0])
+        return results
+
+    async def embed_query(self, text: str) -> list[float]:
+        result = await self.embed([text])
+        return result[0]
+
+
+class CohereEmbeddings:
+    """Cohere embeddings using ``httpx`` (no extra SDK required)."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "embed-english-v3.0",
+        input_type: str = "search_document",
+    ) -> None:
+        self._api_key = api_key or os.environ.get("COHERE_API_KEY", "")
+        self._model = model
+        self._input_type = input_type
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for a list of texts."""
+        import httpx  # noqa: PLC0415
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://api.cohere.com/v1/embed",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "texts": texts,
+                    "model": self._model,
+                    "input_type": self._input_type,
+                    "embedding_types": ["float"],
+                },
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data["embeddings"]["float"]
+
+    async def embed_query(self, text: str) -> list[float]:
+        result = await self.embed([text])
+        return result[0]
+
+
+__all__ = [
+    "CohereEmbeddings",
+    "EmbeddingClient",
+    "OllamaEmbeddings",
+    "OpenAIEmbeddings",
+]


### PR DESCRIPTION
## Context

**Why:** The embeddings module only supported OpenAI. Users running local models (Ollama) or using Cohere had no built-in option, forcing them to write their own adapter or install additional frameworks.

**What:** Add `OllamaEmbeddings` and `CohereEmbeddings` clients that satisfy the existing `EmbeddingClient` protocol, giving users three embedding providers out of the box.

**How:** `OllamaEmbeddings` wraps the `ollama` SDK's async embed endpoint. `CohereEmbeddings` uses raw `httpx` (already a core dep) to call the Cohere API directly — no extra SDK needed. Both implement `embed(texts)` and `embed_query(text)`.

## Summary

| Component | Change | Why |
|-----------|--------|-----|
| `OllamaEmbeddings` | New client using the `ollama` SDK | Local embedding models (nomic-embed-text, etc.) without API keys |
| `CohereEmbeddings` | New client using raw `httpx` | Cohere embeddings with zero extra SDK — httpx is already a core dep |
| `__init__.py` | Export new clients | `from aceteam_aep import OllamaEmbeddings, CohereEmbeddings` |

## Test plan

- [ ] `OllamaEmbeddings` with local Ollama instance
- [ ] `CohereEmbeddings` with Cohere API key
- [ ] Import check: `from aceteam_aep import OllamaEmbeddings, CohereEmbeddings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)