### PR TITLE
fix(safety): detector improvements for demo reliability

### DIFF
--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -61,9 +61,7 @@ def _extract_usage(data: dict[str, Any]) -> tuple[str, int, int]:
     model = data.get("model", "unknown")
     usage = data.get("usage", {})
     input_tokens = usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0) or 0
-    output_tokens = (
-        usage.get("completion_tokens", 0) or usage.get("output_tokens", 0) or 0
-    )
+    output_tokens = usage.get("completion_tokens", 0) or usage.get("output_tokens", 0) or 0
     return model, input_tokens, output_tokens
 
 
@@ -134,7 +132,9 @@ class ProxyState:
 
 def _default_proxy_detectors() -> list[Any]:
     """Default detectors for the proxy."""
-    detectors: list[Any] = [CostAnomalyDetector()]
+    from ..safety.agent_threat import AgentThreatDetector
+
+    detectors: list[Any] = [CostAnomalyDetector(), AgentThreatDetector()]
     try:
         from ..safety.pii import PiiDetector
 
@@ -193,17 +193,12 @@ def create_proxy_app(
                 state.signals.extend(input_signals)
                 state.decisions.append(input_decision)
                 state.call_count += 1
-                log.warning(
-                    "BLOCKED request %s: %s", call_id, input_decision.reason
-                )
+                log.warning("BLOCKED request %s: %s", call_id, input_decision.reason)
                 return JSONResponse(
                     status_code=400,
                     content={
                         "error": {
-                            "message": (
-                                f"AEP safety: request blocked — "
-                                f"{input_decision.reason}"
-                            ),
+                            "message": (f"AEP safety: request blocked — {input_decision.reason}"),
                             "type": "aep_safety_block",
                             "code": "safety_block",
                         }
@@ -246,7 +241,9 @@ def create_proxy_app(
                     total_tokens=inp + out,
                 )
                 state.cost_tracker.record_llm_cost(
-                    span_id=span.span_id, model=model, usage=usage,
+                    span_id=span.span_id,
+                    model=model,
+                    usage=usage,
                 )
                 state.span_tracker.end_span(span.span_id)
                 state.call_count += 1
@@ -328,17 +325,12 @@ def create_proxy_app(
         state.decisions.append(decision)
 
         if decision.action == "block":
-            log.warning(
-                "BLOCKED response %s: %s", call_id, decision.reason
-            )
+            log.warning("BLOCKED response %s: %s", call_id, decision.reason)
             return JSONResponse(
                 status_code=400,
                 content={
                     "error": {
-                        "message": (
-                            f"AEP safety: response blocked — "
-                            f"{decision.reason}"
-                        ),
+                        "message": (f"AEP safety: response blocked — {decision.reason}"),
                         "type": "aep_safety_block",
                         "code": "safety_block",
                     }
@@ -372,10 +364,12 @@ def create_proxy_app(
         from ..dashboard.app import create_app as create_dashboard
 
         dashboard_app = create_dashboard(get_state=state.to_dict)
-        routes.extend([
-            Route("/aep/", dashboard_app.routes[0].endpoint),  # type: ignore[union-attr]
-            Route("/aep/api/state", dashboard_app.routes[1].endpoint),  # type: ignore[union-attr]
-        ])
+        routes.extend(
+            [
+                Route("/aep/", dashboard_app.routes[0].endpoint),  # type: ignore[union-attr]
+                Route("/aep/api/state", dashboard_app.routes[1].endpoint),  # type: ignore[union-attr]
+            ]
+        )
 
     return Starlette(routes=routes)
 

--- a/src/aceteam_aep/proxy/cli.py
+++ b/src/aceteam_aep/proxy/cli.py
@@ -9,6 +9,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib
 import logging
 import os
 import socket
@@ -20,6 +21,16 @@ import time
 log = logging.getLogger(__name__)
 
 
+def _load_detector(path: str) -> object:
+    """Load a detector from a ``module:class`` path string."""
+    if ":" not in path:
+        raise ValueError(f"Invalid detector path '{path}'. Expected format: 'module:ClassName'")
+    module_path, class_name = path.rsplit(":", 1)
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, class_name)
+    return cls()
+
+
 def _find_free_port() -> int:
     """Find a free TCP port on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -27,16 +38,32 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
+def _build_detectors(args: argparse.Namespace) -> list[object] | None:
+    """Build detector list from CLI args."""
+    from ..safety.cost_anomaly import CostAnomalyDetector
+
+    if args.no_safety:
+        return [CostAnomalyDetector()]
+
+    custom = getattr(args, "detector", None)
+    if custom:
+        from .app import _default_proxy_detectors
+
+        detectors = _default_proxy_detectors()
+        for path in custom:
+            detectors.append(_load_detector(path))
+        return detectors
+
+    return None
+
+
 def _run_proxy(args: argparse.Namespace) -> None:
     """Start the AEP reverse proxy."""
     import uvicorn
 
-    from ..safety.cost_anomaly import CostAnomalyDetector
     from .app import create_proxy_app
 
-    detectors = None
-    if args.no_safety:
-        detectors = [CostAnomalyDetector()]
+    detectors = _build_detectors(args)
 
     app = create_proxy_app(
         target_base_url=args.target,
@@ -69,7 +96,6 @@ def _run_wrap(args: argparse.Namespace) -> None:
     """Start proxy, set env vars, run command, print summary on exit."""
     import uvicorn
 
-    from ..safety.cost_anomaly import CostAnomalyDetector
     from .app import create_proxy_app
 
     if not args.cmd:
@@ -78,9 +104,7 @@ def _run_wrap(args: argparse.Namespace) -> None:
 
     port = args.port or _find_free_port()
 
-    detectors = None
-    if args.no_safety:
-        detectors = [CostAnomalyDetector()]
+    detectors = _build_detectors(args)
 
     app = create_proxy_app(
         target_base_url=args.target,
@@ -89,9 +113,7 @@ def _run_wrap(args: argparse.Namespace) -> None:
     )
 
     # Start proxy in a background thread
-    server_config = uvicorn.Config(
-        app, host="127.0.0.1", port=port, log_level="warning"
-    )
+    server_config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(server_config)
     proxy_thread = threading.Thread(target=server.run, daemon=True)
     proxy_thread.start()
@@ -217,6 +239,12 @@ def main() -> None:
     proxy_parser.add_argument(
         "--no-safety", action="store_true", help="Disable safety detectors (cost tracking only)"
     )
+    proxy_parser.add_argument(
+        "--detector",
+        action="append",
+        metavar="MODULE:CLASS",
+        help="Add a custom detector (module:Class). Repeatable.",
+    )
 
     # --- wrap subcommand ---
     wrap_parser = sub.add_parser(
@@ -224,9 +252,7 @@ def main() -> None:
         help="Wrap a command with AEP — intercept all LLM calls",
         epilog="Example: aceteam-aep wrap -- python my_agent.py",
     )
-    wrap_parser.add_argument(
-        "--port", type=int, default=None, help="Proxy port (default: auto)"
-    )
+    wrap_parser.add_argument("--port", type=int, default=None, help="Proxy port (default: auto)")
     wrap_parser.add_argument(
         "--target",
         type=str,
@@ -238,8 +264,12 @@ def main() -> None:
         "--no-safety", action="store_true", help="Disable safety detectors (cost tracking only)"
     )
     wrap_parser.add_argument(
-        "cmd", nargs=argparse.REMAINDER, help="Command to run (after --)"
+        "--detector",
+        action="append",
+        metavar="MODULE:CLASS",
+        help="Add a custom detector (module:Class). Repeatable.",
     )
+    wrap_parser.add_argument("cmd", nargs=argparse.REMAINDER, help="Command to run (after --)")
 
     args = parser.parse_args()
 

--- a/src/aceteam_aep/safety/__init__.py
+++ b/src/aceteam_aep/safety/__init__.py
@@ -1,9 +1,24 @@
-from .base import DetectorRegistry, SafetyDetector, SafetySignal
-from .content import ContentSafetyDetector
-from .cost_anomaly import CostAnomalyDetector
-from .pii import PiiDetector
+import logging
+import os
+import warnings
+
+# Suppress HuggingFace / transformers logging noise at import time so users
+# don't have to.  These run before any transformers or huggingface_hub code
+# is loaded (detectors lazy-load models on first check() call).
+os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+logging.getLogger("transformers").setLevel(logging.ERROR)
+logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
+warnings.filterwarnings("ignore", category=FutureWarning, module=".*safetensors.*")
+
+from .agent_threat import AgentThreatDetector  # noqa: E402
+from .base import DetectorRegistry, SafetyDetector, SafetySignal  # noqa: E402
+from .content import ContentSafetyDetector  # noqa: E402
+from .cost_anomaly import CostAnomalyDetector  # noqa: E402
+from .pii import PiiDetector  # noqa: E402
 
 __all__ = [
+    "AgentThreatDetector",
     "ContentSafetyDetector",
     "CostAnomalyDetector",
     "DetectorRegistry",

--- a/src/aceteam_aep/safety/agent_threat.py
+++ b/src/aceteam_aep/safety/agent_threat.py
@@ -1,0 +1,82 @@
+"""Agent threat detector — regex-based detection of malicious agent behavior.
+
+Detects common attack patterns: port scanning, reverse shells, subprocess
+execution, socket connections, localhost probing, credential file access,
+and destructive commands.
+
+NOTE: This is a regex-based detector — pattern matching on known dangerous
+strings. Easy to bypass with rephrasing or obfuscation. The production
+version will use the Trust Engine's ensemble-of-judges approach
+(LLM-as-judge + classifier fusion) for intent-level detection.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .base import SafetySignal
+
+_THREAT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bnmap\b", re.IGNORECASE), "port scanning (nmap)"),
+    (re.compile(r"\bnetcat\b|\bnc\s+-", re.IGNORECASE), "reverse shell / netcat"),
+    (re.compile(r"\bssh\s+.*-p\b", re.IGNORECASE), "SSH brute force"),
+    (re.compile(r"socket\.connect\(", re.IGNORECASE), "raw socket connection"),
+    (
+        re.compile(r"subprocess\.(run|call|Popen)\(", re.IGNORECASE),
+        "subprocess execution",
+    ),
+    (re.compile(r"os\.(system|popen)\(", re.IGNORECASE), "OS command execution"),
+    (
+        re.compile(r"\bcurl\b.*\blocalhost\b|\bwget\b.*\blocalhost\b", re.IGNORECASE),
+        "localhost probing",
+    ),
+    (re.compile(r"for\s+port\s+in\s+range\(", re.IGNORECASE), "port scan loop"),
+    (
+        re.compile(r"0\.0\.0\.0|127\.0\.0\.1:\d{4,5}", re.IGNORECASE),
+        "internal service targeting",
+    ),
+    (
+        re.compile(r"\b/etc/passwd\b|\b/etc/shadow\b", re.IGNORECASE),
+        "credential file access",
+    ),
+    (re.compile(r"rm\s+-rf\s+/", re.IGNORECASE), "destructive command"),
+]
+
+
+class AgentThreatDetector:
+    """Detect when an AI agent attempts network attacks or system exploitation.
+
+    Scans both input and output text for known dangerous patterns such as
+    port scanning, reverse shells, subprocess execution, and credential access.
+
+    NOTE: This is a regex-based demo detector. The production version will use
+    the Trust Engine's ensemble-of-judges approach (LLM-as-judge + classifier
+    fusion) for intent-level detection.
+    """
+
+    name = "agent_threat"
+
+    def __init__(self) -> None:
+        self._patterns = _THREAT_PATTERNS
+
+    def check(
+        self, *, input_text: str, output_text: str, call_id: str, **kwargs: object
+    ) -> list[SafetySignal]:
+        signals: list[SafetySignal] = []
+        for text, source in [(input_text, "input"), (output_text, "output")]:
+            if not text:
+                continue
+            for pattern, desc in self._patterns:
+                if pattern.search(text):
+                    signals.append(
+                        SafetySignal(
+                            signal_type="agent_threat",
+                            severity="high",
+                            call_id=call_id,
+                            detail=f"{desc} detected in {source}",
+                        )
+                    )
+        return signals
+
+
+__all__ = ["AgentThreatDetector"]

--- a/src/aceteam_aep/safety/pii.py
+++ b/src/aceteam_aep/safety/pii.py
@@ -62,9 +62,15 @@ class PiiDetector:
         if not self._load_attempted:
             self._load()
 
-        if self._fallback:
-            return self._check_regex(output_text, call_id)
-        return self._check_model(output_text, call_id)
+        signals: list[SafetySignal] = []
+        check_fn = self._check_regex if self._fallback else self._check_model
+        for text, source in [(input_text, "input"), (output_text, "output")]:
+            if not text:
+                continue
+            for signal in check_fn(text, call_id):
+                signal.detail = f"{signal.detail} (in {source})"
+                signals.append(signal)
+        return signals
 
     def _check_model(self, text: str, call_id: str) -> list[SafetySignal]:
         assert self._pipeline is not None

--- a/src/aceteam_aep/wrap.py
+++ b/src/aceteam_aep/wrap.py
@@ -28,6 +28,8 @@ Supports:
 
 from __future__ import annotations
 
+import logging
+import os
 import uuid
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -40,10 +42,14 @@ from .safety.cost_anomaly import CostAnomalyDetector
 from .spans import Span, SpanTracker
 from .types import Usage
 
+log = logging.getLogger(__name__)
+
 
 def _default_detectors() -> list[Any]:
     """Build the default detector list. Model-based detectors only if available."""
-    detectors: list[Any] = [CostAnomalyDetector()]
+    from .safety.agent_threat import AgentThreatDetector
+
+    detectors: list[Any] = [CostAnomalyDetector(), AgentThreatDetector()]
     try:
         from .safety.pii import PiiDetector
 
@@ -57,6 +63,25 @@ def _default_detectors() -> list[Any]:
     except Exception:
         pass
     return detectors
+
+
+class AepPreflightBlock(Exception):
+    """Raised when pre-flight safety checks block a request."""
+
+    def __init__(self, decision: EnforcementDecision, signals: list[SafetySignal]) -> None:
+        self.decision = decision
+        self.signals = signals
+        super().__init__(f"AEP pre-flight blocked: {decision.reason}")
+
+
+def _snippet(text: str, n: int = 5) -> str:
+    """First and last *n* lines, with a separator if truncated."""
+    lines = text.strip().splitlines()
+    if len(lines) <= n * 2:
+        return text.strip()
+    head = "\n".join(lines[:n])
+    tail = "\n".join(lines[-n:])
+    return f"{head}\n  ... ({len(lines) - n * 2} lines omitted) ...\n{tail}"
 
 
 @dataclass
@@ -74,6 +99,7 @@ class AepSession:
         default_factory=lambda: EnforcementDecision(action="pass")
     )
     _call_count: int = 0
+    _verbose: bool = False
 
     @property
     def cost_usd(self) -> Decimal:
@@ -123,6 +149,57 @@ class AepSession:
 
         serve(self, port=port)
 
+    def preflight_check(self, *, input_text: str, call_id: str) -> None:
+        """Run detectors on input text before the API call.
+
+        Raises ``AepPreflightBlock`` if any detector returns a HIGH severity
+        signal that the enforcement policy would block.
+        """
+        if not input_text:
+            return
+
+        signals = self._registry.run_all(
+            input_text=input_text,
+            output_text="",
+            call_id=call_id,
+        )
+        if signals:
+            decision = evaluate(signals, self._policy)
+            if decision.action == "block":
+                self._safety_signals.extend(signals)
+                self._last_enforcement = decision
+                self._call_count += 1
+                raise AepPreflightBlock(decision, signals)
+
+    def _log_verbose(
+        self,
+        *,
+        call_id: str,
+        input_text: str,
+        output_text: str,
+        signals: list[SafetySignal],
+        enforcement: EnforcementDecision,
+    ) -> None:
+        """Print input/output snippets and detector results when verbose."""
+        _DIM = "\033[2m"
+        _CYAN = "\033[36m"
+        _RESET = "\033[0m"
+        print(f"\n{_DIM}{'─' * 60}{_RESET}")
+        print(f"{_CYAN}[AEP] call_id={call_id}{_RESET}")
+        print(f"{_DIM}INPUT  >{_RESET}")
+        for line in _snippet(input_text).splitlines():
+            print(f"  {_DIM}{line}{_RESET}")
+        print(f"{_DIM}OUTPUT >{_RESET}")
+        for line in _snippet(output_text).splitlines():
+            print(f"  {_DIM}{line}{_RESET}")
+        print(f"{_DIM}ENFORCEMENT > {enforcement.action.upper()}{_RESET}")
+        if signals:
+            for s in signals:
+                print(f"  {_DIM}[{s.severity.upper()}] {s.signal_type}: {s.detail}{_RESET}")
+        else:
+            print(f"  {_DIM}(no signals){_RESET}")
+        print(f"{_DIM}{'─' * 60}{_RESET}")
+
     def _record_call(
         self,
         model: str,
@@ -170,6 +247,15 @@ class AepSession:
         # Evaluate enforcement on the new signals
         self._last_enforcement = evaluate(signals, self._policy)
 
+        if self._verbose:
+            self._log_verbose(
+                call_id=call_id,
+                input_text=input_text,
+                output_text=output_text,
+                signals=signals,
+                enforcement=self._last_enforcement,
+            )
+
 
 # ---------------------------------------------------------------------------
 # OpenAI wrapper
@@ -182,6 +268,11 @@ def _wrap_openai(client: Any, session: AepSession) -> Any:
 
     def patched_create(*args: Any, **kwargs: Any) -> Any:
         call_id = uuid.uuid4().hex[:8]
+
+        # Pre-flight: check input before sending to LLM
+        input_text = _extract_input_text(kwargs.get("messages", []))
+        session.preflight_check(input_text=input_text, call_id=call_id)
+
         result = original_create(*args, **kwargs)
 
         try:
@@ -219,6 +310,11 @@ def _wrap_openai_async(client: Any, session: AepSession) -> Any:
 
     async def patched_create(*args: Any, **kwargs: Any) -> Any:
         call_id = uuid.uuid4().hex[:8]
+
+        # Pre-flight: check input before sending to LLM
+        input_text = _extract_input_text(kwargs.get("messages", []))
+        session.preflight_check(input_text=input_text, call_id=call_id)
+
         result = await original_create(*args, **kwargs)
 
         try:
@@ -261,6 +357,11 @@ def _wrap_anthropic(client: Any, session: AepSession) -> Any:
 
     def patched_create(*args: Any, **kwargs: Any) -> Any:
         call_id = uuid.uuid4().hex[:8]
+
+        # Pre-flight: check input before sending to LLM
+        input_text = _extract_input_text(kwargs.get("messages", []))
+        session.preflight_check(input_text=input_text, call_id=call_id)
+
         result = original_create(*args, **kwargs)
 
         try:
@@ -297,6 +398,11 @@ def _wrap_anthropic_async(client: Any, session: AepSession) -> Any:
 
     async def patched_create(*args: Any, **kwargs: Any) -> Any:
         call_id = uuid.uuid4().hex[:8]
+
+        # Pre-flight: check input before sending to LLM
+        input_text = _extract_input_text(kwargs.get("messages", []))
+        session.preflight_check(input_text=input_text, call_id=call_id)
+
         result = await original_create(*args, **kwargs)
 
         try:
@@ -349,6 +455,7 @@ def wrap(
     entity: str = "default",
     detectors: list[Any] | None = None,
     policy: EnforcementPolicy | None = None,
+    verbose: bool = False,
 ) -> Any:
     """Wrap any OpenAI or Anthropic client with AEP accountability + T&S.
 
@@ -360,6 +467,8 @@ def wrap(
                    (PII, content safety, cost anomaly).
         policy: Custom EnforcementPolicy. If None, uses default (block on high,
                 flag on medium).
+        verbose: Print input/output snippets and detector results for each call.
+                 Also enabled by setting the ``AEP_LOG=1`` environment variable.
 
     Returns:
         The same client object, mutated in-place with AEP instrumentation.
@@ -381,6 +490,7 @@ def wrap(
     session = AepSession(
         entity=entity,
         _policy=policy or EnforcementPolicy(),
+        _verbose=verbose or os.environ.get("AEP_LOG", "") in ("1", "true", "yes"),
     )
 
     # Register detectors
@@ -420,4 +530,4 @@ def _extract_input_text(messages: list[Any]) -> str:
     return " ".join(parts)
 
 
-__all__ = ["AepSession", "SafetySignal", "wrap"]
+__all__ = ["AepPreflightBlock", "AepSession", "SafetySignal", "wrap"]


### PR DESCRIPTION
## Context

**Why** — During demo prep, 6 issues found that affect demo reliability and developer experience. PII detection was inconsistent (only scanning output, not input), no way to add custom detectors to the proxy, and wrap() didn't pre-flight block.

**What** — Six fixes across the safety module, proxy CLI, and wrap() function.

**How** — Minimal changes to existing interfaces. All backward-compatible.

## Summary

| Fix | File | Impact |
|-----|------|--------|
| PII scans both input + output | `safety/pii.py` | BLOCK now triggers on PII in prompts, not just responses |
| `--detector` flag for proxy CLI | `proxy/cli.py` | `aceteam-aep proxy --detector module:Class` loads custom detectors |
| Built-in AgentThreatDetector | `safety/agent_threat.py` | 11 regex patterns for port scans, shells, subprocess, etc. |
| Pre-flight blocking in wrap() | `wrap.py` | Detectors run on input BEFORE the API call. Raises `AepPreflightBlock` on HIGH severity. |
| Verbose mode | `wrap.py` | `wrap(client, verbose=True)` or `AEP_LOG=1` prints detector I/O |
| Suppress HF noise | `safety/__init__.py` | No more loading bars, safetensors warnings, or conversion spam |

## Test plan

- [x] 232 existing tests pass
- [x] Ruff check + format clean
- [ ] Manual: `uv run python -c "from aceteam_aep.safety.agent_threat import AgentThreatDetector"`
- [ ] Manual: demo with `aep-quickstart/main.py` — PII should BLOCK reliably

---
*Generated by Claude*