### PR TITLE
fix(proxy): dashboard path, --host flag, governance headers and display

### DIFF
--- a/src/aceteam_aep/dashboard/templates/index.html
+++ b/src/aceteam_aep/dashboard/templates/index.html
@@ -61,6 +61,11 @@
   <div id="signals"></div>
 </div>
 
+<div class="section" id="governance-section" style="display:none;">
+  <h2>Governance Context</h2>
+  <div id="governance"></div>
+</div>
+
 <div class="section">
   <h2>Call Timeline</h2>
   <div id="spans"></div>
@@ -113,6 +118,35 @@ function renderSignals(container, signals) {
   });
 }
 
+function renderGovernance(container, gov) {
+  var section = document.getElementById('governance-section');
+  if (!gov) { section.style.display = 'none'; return; }
+  section.style.display = '';
+  container.textContent = '';
+  var fields = [
+    ['Entity', gov.entity],
+    ['Classification', gov.classification],
+    ['Consent', gov.consent ? Object.keys(gov.consent).map(function(k){ return k + '=' + gov.consent[k]; }).join(', ') : null],
+    ['Budget', gov.budget],
+    ['Sources', gov.sources && gov.sources.length ? gov.sources.join(', ') : null],
+    ['Trace ID', gov.trace_id]
+  ];
+  fields.forEach(function(f) {
+    if (!f[1]) return;
+    var row = document.createElement('div');
+    row.className = 'span-item';
+    var label = document.createElement('span');
+    label.className = 'span-model';
+    label.textContent = f[0];
+    row.appendChild(label);
+    var val = document.createElement('span');
+    val.className = 'span-dur';
+    val.textContent = String(f[1]);
+    row.appendChild(val);
+    container.appendChild(row);
+  });
+}
+
 function renderSpans(container, spans) {
   container.textContent = '';
   if (spans.length === 0) {
@@ -142,12 +176,13 @@ function renderSpans(container, spans) {
 
 async function refresh() {
   try {
-    var res = await fetch('/api/state');
+    var res = await fetch('api/state');
     var data = await res.json();
     document.getElementById('cost').textContent = '$' + data.cost.toFixed(6);
     document.getElementById('calls').textContent = String(data.calls);
     setBadge(document.getElementById('status'), data.action);
     renderSignals(document.getElementById('signals'), data.signals);
+    renderGovernance(document.getElementById('governance'), data.governance);
     renderSpans(document.getElementById('spans'), data.spans);
   } catch (e) {}
 }

--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -24,6 +24,7 @@ from ..safety.base import DetectorRegistry, SafetySignal
 from ..safety.cost_anomaly import CostAnomalyDetector
 from ..spans import SpanTracker
 from ..types import Usage
+from .headers import build_response_headers, parse_aep_headers, strip_aep_headers
 
 log = logging.getLogger(__name__)
 
@@ -83,6 +84,7 @@ class ProxyState:
         self.call_count = 0
         self.decisions: list[EnforcementDecision] = []
         self._call_costs: list[Decimal] = []
+        self.governance_contexts: list[dict[str, Any]] = []
 
         # Register detectors
         for det in detectors or _default_proxy_detectors():
@@ -127,6 +129,7 @@ class ProxyState:
                 }
                 for s in self.span_tracker.get_spans()
             ],
+            "governance": self.governance_contexts[-1] if self.governance_contexts else None,
         }
 
 
@@ -176,6 +179,20 @@ def create_proxy_app(
         except json.JSONDecodeError:
             body = {}
 
+        # --- PARSE AEP GOVERNANCE HEADERS ---
+        aep_ctx = parse_aep_headers(request.headers)
+        if aep_ctx.entity != "default" or aep_ctx.classification != "public" or aep_ctx.consent:
+            state.governance_contexts.append(
+                {
+                    "entity": aep_ctx.entity,
+                    "classification": aep_ctx.classification,
+                    "consent": aep_ctx.consent,
+                    "budget": str(aep_ctx.budget) if aep_ctx.budget is not None else None,
+                    "sources": aep_ctx.sources,
+                    "trace_id": aep_ctx.trace_id,
+                }
+            )
+
         # --- INPUT SAFETY CHECK ---
         input_text = ""
         if "messages" in body:
@@ -208,7 +225,7 @@ def create_proxy_app(
         # --- FORWARD TO TARGET API ---
         target_url = f"{state.target_base_url}{path}"
 
-        # Forward headers (especially Authorization)
+        # Forward headers (especially Authorization), stripping AEP governance headers
         forward_headers: dict[str, str] = {}
         if request.headers.get("authorization"):
             forward_headers["Authorization"] = request.headers["authorization"]
@@ -218,6 +235,8 @@ def create_proxy_app(
         for key in ("x-api-key", "anthropic-version"):
             if request.headers.get(key):
                 forward_headers[key] = request.headers[key]
+        # Strip X-AEP-* headers so they don't leak to the LLM provider
+        forward_headers = strip_aep_headers(forward_headers)
 
         # --- STREAMING BRANCH ---
         if body.get("stream"):
@@ -338,13 +357,14 @@ def create_proxy_app(
             )
 
         # --- PASS THROUGH (with AEP metadata header) ---
-        resp_headers = {
-            "X-AEP-Cost": str(cost_node.compute_cost),
-            "X-AEP-Enforcement": decision.action,
-            "X-AEP-Call-ID": call_id,
-        }
-        if decision.action == "flag":
-            resp_headers["X-AEP-Flag-Reason"] = decision.reason
+        resp_headers = build_response_headers(
+            cost=cost_node.compute_cost,
+            enforcement=decision.action,
+            call_id=call_id,
+            classification=aep_ctx.classification,
+            flag_reason=decision.reason if decision.action == "flag" else "",
+            trace_id=aep_ctx.trace_id,
+        )
 
         return Response(
             content=upstream_resp.content,

--- a/src/aceteam_aep/proxy/cli.py
+++ b/src/aceteam_aep/proxy/cli.py
@@ -89,7 +89,7 @@ def _run_proxy(args: argparse.Namespace) -> None:
         f"\n"
     )
 
-    uvicorn.run(app, host="127.0.0.1", port=args.port, log_level="info")
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
 
 
 def _run_wrap(args: argparse.Namespace) -> None:
@@ -113,7 +113,8 @@ def _run_wrap(args: argparse.Namespace) -> None:
     )
 
     # Start proxy in a background thread
-    server_config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    host = args.host
+    server_config = uvicorn.Config(app, host=host, port=port, log_level="warning")
     server = uvicorn.Server(server_config)
     proxy_thread = threading.Thread(target=server.run, daemon=True)
     proxy_thread.start()
@@ -227,6 +228,9 @@ def main() -> None:
         "--port", type=int, default=8899, help="Port to listen on (default: 8899)"
     )
     proxy_parser.add_argument(
+        "--host", type=str, default="127.0.0.1", help="Host to bind to (default: 127.0.0.1)"
+    )
+    proxy_parser.add_argument(
         "--target",
         type=str,
         default="https://api.openai.com",
@@ -253,6 +257,9 @@ def main() -> None:
         epilog="Example: aceteam-aep wrap -- python my_agent.py",
     )
     wrap_parser.add_argument("--port", type=int, default=None, help="Proxy port (default: auto)")
+    wrap_parser.add_argument(
+        "--host", type=str, default="127.0.0.1", help="Host to bind to (default: 127.0.0.1)"
+    )
     wrap_parser.add_argument(
         "--target",
         type=str,


### PR DESCRIPTION
## Context

**Why** — Dashboard fetch failed when mounted at /aep/ (absolute path). Proxy couldn't bind to 0.0.0.0 for Docker. No governance header support in proxy mode.

**What** — Five fixes for proxy reliability and governance support.

**How** — Minimal changes to existing interfaces. All backward-compatible.

## Summary

| Fix | File | Impact |
|-----|------|--------|
| Dashboard fetch path | `dashboard/templates/index.html` | `'/api/state'` → `'api/state'` (relative) |
| `--host` flag | `proxy/cli.py` | `aceteam-aep proxy --host 0.0.0.0` for Docker |
| Governance headers | `proxy/app.py` | Parse X-AEP-* on input, strip before forwarding, include in response |
| ProxyState governance | `proxy/app.py` | Track entity, classification, consent, budget per call |
| Dashboard governance | `dashboard/templates/index.html` | Show governance context when present |

## Test plan

- [x] 232 tests pass
- [x] Ruff clean
- [ ] Manual: proxy with `--host 0.0.0.0` in Docker
- [ ] Manual: send X-AEP-Entity header, verify dashboard shows it

---
*Generated by Claude*