### PR TITLE
feat: GHCR Docker image + policy auto-discovery (#40, #38)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: aceteam-ai/aep-proxy
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,25 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Copy project files
-COPY pyproject.toml .
+COPY pyproject.toml README.md ./
 COPY src/ src/
 
 # Install with proxy + safety extras
 RUN uv pip install --system ".[proxy,safety]"
 
+# Pre-download safety models so first call isn't slow (~235MB)
+RUN python -c "\
+from transformers import AutoTokenizer, AutoModelForTokenClassification, AutoModelForSequenceClassification; \
+AutoTokenizer.from_pretrained('iiiorg/piiranha-v1-detect-personal-information'); \
+AutoModelForTokenClassification.from_pretrained('iiiorg/piiranha-v1-detect-personal-information'); \
+AutoTokenizer.from_pretrained('s-nlp/roberta_toxicity_classifier'); \
+AutoModelForSequenceClassification.from_pretrained('s-nlp/roberta_toxicity_classifier'); \
+print('Models cached')" 2>/dev/null || echo "Model pre-download skipped (no torch)"
+
 EXPOSE 8899
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8899/aep/api/state')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8899/aep/')" || exit 1
 
 ENTRYPOINT ["aceteam-aep"]
-CMD ["proxy", "--port", "8899"]
+CMD ["proxy", "--port", "8899", "--host", "0.0.0.0"]

--- a/examples/policies/permissive.yaml
+++ b/examples/policies/permissive.yaml
@@ -1,0 +1,22 @@
+# AEP Enforcement Policy — Permissive (development, testing)
+#
+# Only block high-severity agent threats. Everything else passes.
+# Good for development where you want visibility without interruption.
+
+default_action: pass
+block_on: [high]
+flag_on: []
+
+detectors:
+  pii:
+    enabled: true
+    action: flag
+  content_safety:
+    enabled: false
+  agent_threat:
+    enabled: true
+    action: block
+  cost_anomaly:
+    enabled: true
+    action: pass
+    multiplier: 10

--- a/examples/policies/production.yaml
+++ b/examples/policies/production.yaml
@@ -1,0 +1,26 @@
+# AEP Enforcement Policy — Production (recommended)
+#
+# Block high-severity signals. Flag medium. Pass low.
+# All detectors enabled with sensible defaults.
+#
+# Place as aep-policy.yaml in your project root, or set AEP_POLICY env var.
+
+default_action: flag
+block_on: [high]
+flag_on: [medium]
+
+detectors:
+  pii:
+    enabled: true
+    action: block
+  content_safety:
+    enabled: true
+    action: flag
+    threshold: 0.7
+  agent_threat:
+    enabled: true
+    action: block
+  cost_anomaly:
+    enabled: true
+    action: flag
+    multiplier: 5

--- a/examples/policies/strict.yaml
+++ b/examples/policies/strict.yaml
@@ -1,0 +1,25 @@
+# AEP Enforcement Policy — Strict (healthcare, finance, government)
+#
+# Block on medium and high. Low cost anomaly threshold.
+# All detectors enabled with aggressive thresholds.
+
+default_action: block
+block_on: [high, medium]
+flag_on: [low]
+
+detectors:
+  pii:
+    enabled: true
+    action: block
+    threshold: 0.5
+  content_safety:
+    enabled: true
+    action: block
+    threshold: 0.5
+  agent_threat:
+    enabled: true
+    action: block
+  cost_anomaly:
+    enabled: true
+    action: block
+    multiplier: 3

--- a/src/aceteam_aep/enforcement.py
+++ b/src/aceteam_aep/enforcement.py
@@ -62,8 +62,9 @@ class EnforcementPolicy:
                     action=cfg.get("action", "block"),
                     threshold=cfg.get("threshold"),
                     enabled=cfg.get("enabled", True),
-                    extra={k: v for k, v in cfg.items()
-                           if k not in ("action", "threshold", "enabled")},
+                    extra={
+                        k: v for k, v in cfg.items() if k not in ("action", "threshold", "enabled")
+                    },
                 )
 
         return cls(
@@ -196,6 +197,7 @@ def build_detectors_from_policy(policy: EnforcementPolicy) -> list[Any]:
     if not pii_cfg or pii_cfg.enabled:
         try:
             from .safety.pii import PiiDetector
+
             detectors.append(PiiDetector())
         except Exception:
             pass
@@ -205,6 +207,7 @@ def build_detectors_from_policy(policy: EnforcementPolicy) -> list[Any]:
     if not content_cfg or content_cfg.enabled:
         try:
             from .safety.content import ContentSafetyDetector
+
             threshold = content_cfg.threshold if content_cfg and content_cfg.threshold else 0.7
             detectors.append(ContentSafetyDetector(threshold=threshold))
         except Exception:
@@ -213,10 +216,56 @@ def build_detectors_from_policy(policy: EnforcementPolicy) -> list[Any]:
     return detectors
 
 
+DEFAULT_POLICY = EnforcementPolicy()
+
+
+def discover_policy(explicit: str | Path | None = None) -> EnforcementPolicy:
+    """Auto-discover enforcement policy using a priority chain.
+
+    Discovery order:
+    1. Explicit path argument (if provided)
+    2. AEP_POLICY environment variable
+    3. File discovery: aep-policy.yaml or .aep/policy.yaml walking up from CWD
+    4. Built-in default policy
+    """
+    import os
+
+    # 1. Explicit argument
+    if explicit is not None:
+        return EnforcementPolicy.from_yaml(explicit)
+
+    # 2. Environment variable
+    env_path = os.environ.get("AEP_POLICY")
+    if env_path:
+        p = Path(env_path)
+        if p.is_file():
+            return EnforcementPolicy.from_yaml(p)
+        raise FileNotFoundError(f"AEP_POLICY={env_path} does not exist")
+
+    # 3. File discovery — walk up from CWD
+    home = Path.home()
+    cwd = Path.cwd().resolve()
+    search = cwd
+    while True:
+        for candidate in ("aep-policy.yaml", ".aep/policy.yaml"):
+            policy_file = search / candidate
+            if policy_file.is_file():
+                return EnforcementPolicy.from_yaml(policy_file)
+        parent = search.parent
+        if parent == search or search == home:
+            break
+        search = parent
+
+    # 4. Built-in default
+    return DEFAULT_POLICY
+
+
 __all__ = [
+    "DEFAULT_POLICY",
     "DetectorPolicy",
     "EnforcementDecision",
     "EnforcementPolicy",
     "build_detectors_from_policy",
+    "discover_policy",
     "evaluate",
 ]


### PR DESCRIPTION
## Context

**Why** — SafeClaw sidecar installs aceteam-aep at container startup (30-60s, fragile). And enforcement policy is hardcoded with no way to customize per org.

**What** — Pre-built Docker image for GHCR + automatic policy discovery chain.

**How** — Dockerfile pre-downloads safety models, binds 0.0.0.0. GitHub Actions builds on tag push. discover_policy() walks up dirs for aep-policy.yaml.

## Summary

| Component | What |
|-----------|------|
| `Dockerfile` | Pre-download models, `--host 0.0.0.0`, healthcheck |
| `.github/workflows/docker-publish.yml` | Build + push to ghcr.io/aceteam-ai/aep-proxy on tag |
| `enforcement.py` | `discover_policy()`: explicit > AEP_POLICY env > file walk > default |
| `examples/policies/` | production.yaml, strict.yaml, permissive.yaml |

## Test plan

- [x] 277 tests pass
- [x] Ruff clean
- [ ] Docker build succeeds locally (building now)
- [ ] Docker healthcheck passes

Closes #40, closes #38.
