### PR TITLE
feat: AEP as MCP server — safety for any agent (#56)

### DIFF
--- a/src/aceteam_aep/mcp.py
+++ b/src/aceteam_aep/mcp.py
@@ -1,0 +1,236 @@
+"""AEP MCP Server — safety enforcement as an MCP tool.
+
+Registers as an MCP server that provides safety checking as a tool.
+Any MCP-compatible agent (Claude Code, OpenClaw, Codex) gets safety
+enforcement by adding one config line.
+
+Usage in claude_desktop_config.json or OpenClaw settings::
+
+    {
+      "mcpServers": {
+        "aep-safety": {
+          "command": "aceteam-aep",
+          "args": ["mcp-server"]
+        }
+      }
+    }
+
+Or with a policy::
+
+    {
+      "mcpServers": {
+        "aep-safety": {
+          "command": "aceteam-aep",
+          "args": ["mcp-server", "--policy", "strict.yaml"]
+        }
+      }
+    }
+
+The server exposes one tool: ``check_safety`` which evaluates text
+for safety signals and returns PASS/FLAG/BLOCK verdicts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def _build_detectors(policy_path: str | None = None) -> tuple[Any, Any]:
+    """Build detectors and policy from optional policy path."""
+    from .enforcement import EnforcementPolicy, build_detectors_from_policy
+    from .safety.base import DetectorRegistry
+
+    if policy_path:
+        policy = EnforcementPolicy.from_yaml(policy_path)
+        detectors = build_detectors_from_policy(policy)
+    else:
+        from .safety.agent_threat import AgentThreatDetector
+        from .safety.cost_anomaly import CostAnomalyDetector
+
+        policy = EnforcementPolicy()
+        detectors = [CostAnomalyDetector(), AgentThreatDetector()]
+        try:
+            from .safety.pii import PiiDetector
+
+            detectors.append(PiiDetector())
+        except Exception:
+            pass
+
+    registry = DetectorRegistry()
+    for det in detectors:
+        registry.add(det)
+
+    return registry, policy
+
+
+def run_mcp_server(policy_path: str | None = None) -> None:
+    """Run the AEP safety MCP server using stdin/stdout JSON-RPC."""
+    registry, policy = _build_detectors(policy_path)
+
+    from .enforcement import evaluate
+
+    # MCP uses JSON-RPC 2.0 over stdin/stdout
+    tools = [
+        {
+            "name": "check_safety",
+            "description": (
+                "Check text for safety issues. Returns PASS, FLAG, or BLOCK "
+                "with details about any detected threats (PII, toxicity, "
+                "agent attacks, policy violations). Use before executing "
+                "any potentially risky action."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                        "description": "The text to check for safety issues",
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "Optional context (e.g. 'agent wants to execute this code')",
+                    },
+                },
+                "required": ["text"],
+            },
+        },
+        {
+            "name": "get_safety_status",
+            "description": (
+                "Get current safety session status: total calls checked, "
+                "signals raised, current enforcement action."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+            },
+        },
+    ]
+
+    call_count = 0
+    all_signals: list[Any] = []
+
+    def handle_request(req: dict[str, Any]) -> dict[str, Any]:
+        nonlocal call_count
+
+        method = req.get("method", "")
+        req_id = req.get("id")
+        params = req.get("params", {})
+
+        if method == "initialize":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": "aep-safety",
+                        "version": "0.5.6",
+                    },
+                },
+            }
+
+        if method == "notifications/initialized":
+            return {}  # no response needed
+
+        if method == "tools/list":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"tools": tools},
+            }
+
+        if method == "tools/call":
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments", {})
+
+            if tool_name == "check_safety":
+                text = arguments.get("text", "")
+                context = arguments.get("context", "")
+                call_id = f"mcp-{call_count}"
+                call_count += 1
+
+                signals = registry.run_all(
+                    input_text=text,
+                    output_text=context,
+                    call_id=call_id,
+                )
+                all_signals.extend(signals)
+
+                decision = evaluate(signals, policy)
+
+                result_text = f"**{decision.action.upper()}**"
+                if signals:
+                    result_text += "\n\nSignals detected:"
+                    for s in signals:
+                        result_text += f"\n- [{s.severity.upper()}] {s.signal_type}: {s.detail}"
+                if decision.reason:
+                    result_text += f"\n\nReason: {decision.reason}"
+                if not signals:
+                    result_text += " — No safety issues detected."
+
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "content": [{"type": "text", "text": result_text}],
+                    },
+                }
+
+            if tool_name == "get_safety_status":
+                status = (
+                    f"AEP Safety Status:\n"
+                    f"- Calls checked: {call_count}\n"
+                    f"- Total signals: {len(all_signals)}\n"
+                    f"- Policy: {'custom' if policy_path else 'default'}"
+                )
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "content": [{"type": "text", "text": status}],
+                    },
+                }
+
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
+            }
+
+        # Unknown method
+        if req_id is not None:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Unknown method: {method}"},
+            }
+        return {}
+
+    # Main loop: read JSON-RPC from stdin, write to stdout
+    log.info("AEP MCP server starting (stdin/stdout)")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+            resp = handle_request(req)
+            if resp:
+                sys.stdout.write(json.dumps(resp) + "\n")
+                sys.stdout.flush()
+        except Exception as e:
+            log.error("MCP error: %s", e)
+            error_resp = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32603, "message": str(e)},
+            }
+            sys.stdout.write(json.dumps(error_resp) + "\n")
+            sys.stdout.flush()

--- a/src/aceteam_aep/proxy/cli.py
+++ b/src/aceteam_aep/proxy/cli.py
@@ -494,6 +494,18 @@ def main() -> None:
     )
     wrap_parser.add_argument("cmd", nargs=argparse.REMAINDER, help="Command to run (after --)")
 
+    # --- mcp-server subcommand ---
+    mcp_parser = sub.add_parser(
+        "mcp-server",
+        help="Start AEP safety as an MCP server (stdin/stdout JSON-RPC)",
+    )
+    mcp_parser.add_argument(
+        "--policy",
+        type=str,
+        default=None,
+        help="Path to AEP policy YAML file",
+    )
+
     args = parser.parse_args()
 
     # Strip leading "--" from cmd if present
@@ -508,6 +520,10 @@ def main() -> None:
         _run_keygen(args)
     elif args.command == "verify":
         _run_verify(args)
+    elif args.command == "mcp-server":
+        from ..mcp import run_mcp_server
+
+        run_mcp_server(policy_path=args.policy)
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
## Context

**Why** — Any MCP-compatible agent should get safety with one config line. No proxy setup, no code changes.

**What** — `aceteam-aep mcp-server` CLI command. JSON-RPC over stdin/stdout. Exposes `check_safety` and `get_safety_status` tools.

**How** — Standard MCP protocol (JSON-RPC 2.0). Tools use the same detector registry and enforcement policy as the proxy.

## Usage

```json
{
  "mcpServers": {
    "aep-safety": {
      "command": "aceteam-aep",
      "args": ["mcp-server"]
    }
  }
}
```

Works with: Claude Code, OpenClaw, Codex, OpenCode, any MCP client.

## Test plan

- [x] 338 tests pass
- [x] Ruff clean
- [ ] Manual: test with Claude Code MCP config

Closes #56.