### PR TITLE
docs: architecture update — gateway, MCP, tiers, setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-# aceteam-aep
+# aceteam-aep — SafeClaw Gateway
 
 [![PyPI](https://img.shields.io/pypi/v/aceteam-aep)](https://pypi.org/project/aceteam-aep/)
 [![AEP Safe](https://img.shields.io/badge/AEP-Safe-brightgreen)](https://github.com/aceteam-ai/aceteam-aep)
 
 AceTeam™ trust & safety infrastructure for AI agents. The Agentic Execution Protocol™ (AEP™) adds cost tracking, safety detection, and enforcement to any LLM-powered tool — **zero code changes required.**
+
+The gateway runs a single process on one port with three interfaces:
+
+| Path | What it does |
+|------|-------------|
+| `/v1/*` | OpenAI-compatible reverse proxy with safety enforcement |
+| `/aep/` | Dashboard — cost, signals, policy controls, setup wizard |
+| `/mcp/` | MCP tools for Claude Code and any MCP client |
 
 ## Installation
 
@@ -13,21 +21,35 @@ pip install aceteam-aep[safety,proxy]      # Safety detectors + proxy
 pip install aceteam-aep                    # Core only (cost tracking + regex safety)
 ```
 
-## Quick Start — Make OpenClaw (or any agent) Safe
-
-No code changes. Just run the proxy and point your agent at it:
+## Quick Start
 
 ```bash
-# Terminal 1: Start the AEP safety proxy
-aceteam-aep proxy --port 8080
+# Install and start the gateway
+pip install aceteam-aep[all]
+aceteam-aep proxy
+```
 
-# Terminal 2: Run OpenClaw through the proxy
-export OPENAI_BASE_URL=http://localhost:8080/v1
+The gateway prints three URLs on startup:
+
+```
+  SafeClaw Gateway
+  ───────────────────────────────────
+  LLM Proxy:  http://localhost:8899/v1
+  Dashboard:  http://localhost:8899/aep/
+  MCP:        http://localhost:8899/mcp/
+```
+
+Open the dashboard — a **setup wizard** appears on first visit and walks you through pointing your agent at the proxy or configuring Claude Code.
+
+**Point an agent at the gateway:**
+
+```bash
+export OPENAI_BASE_URL=http://localhost:8899/v1
 export OPENAI_API_KEY=sk-your-key
 openclaw run "analyze these financial statements"
 ```
 
-Open **http://localhost:8080/aep/** — the dashboard shows every LLM call flowing through in real-time: cost, safety signals, and enforcement decisions.
+Open **http://localhost:8899/aep/** — every LLM call appears in real-time with cost, safety signals, and enforcement decisions.
 
 The proxy intercepts **both directions**:
 - **Incoming requests** — blocks dangerous prompts before they reach the API
@@ -246,6 +268,25 @@ One env var. Zero code changes. The agent doesn't know AEP exists.
 
 **Tested with NVIDIA NemoClaw/OpenShell:** Agent threats (port scanning, subprocess execution) blocked at the proxy before reaching the LLM. Normal calls pass through with receipts. See [aep-quickstart](https://github.com/aceteam-ai/aep-quickstart) for the full NemoClaw demo.
 
+## Claude Code Integration
+
+Add the gateway as an MCP server in your Claude Code config:
+
+```json
+{
+  "mcpServers": {
+    "aceteam": {
+      "type": "streamable-http",
+      "url": "http://localhost:8899/mcp/"
+    }
+  }
+}
+```
+
+This gives Claude four tools: `check_safety`, `get_safety_status`, `set_safety_policy`, and `get_cost_summary`. All tools share live state with the proxy — safety checks via MCP appear in the dashboard and affect traffic enforcement.
+
+See [docs/engineering/mcp-integration.md](docs/engineering/mcp-integration.md) for full tool reference.
+
 ## Dashboard
 
 Two views — toggle between Developer and Executive:
@@ -253,6 +294,10 @@ Two views — toggle between Developer and Executive:
 **Developer:** Individual calls, safety signals, cost per call, governance context, call timeline.
 
 **Executive:** Enforcement coverage %, threats blocked, compliance status (PII/threats/toxicity/anomalies), safety breakdown, cost attribution by entity.
+
+**Policy controls:** Per-detector checkboxes and per-category Trust Engine toggles — adjust enforcement without restarting. The master safety toggle in the header disables all detectors instantly.
+
+**Setup wizard:** Shows on first visit (zero calls). Guides through API key configuration and agent setup — provides the `OPENAI_BASE_URL` export command and Claude Code MCP config to copy.
 
 ```python
 client.aep.serve_dashboard()  # http://localhost:8899

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -1,197 +1,129 @@
-# AEP Architecture
+# AEP Gateway Architecture
 
 ## Overview
 
-AEP (Agentic Execution Protocol) provides safety and accountability for AI agents through two deployment modes:
+The AEP Gateway (SafeClaw) is a unified process serving three endpoints on a single port:
 
-1. **Wrap mode** — Python SDK that monkey-patches LLM client libraries (OpenAI, Anthropic) to intercept calls in-process
-2. **Proxy mode** — HTTP reverse proxy that intercepts all LLM traffic at the network level
+| Path | Protocol | Purpose |
+|------|----------|---------|
+| `/v1/*` | OpenAI-compatible HTTP | LLM reverse proxy with safety enforcement |
+| `/aep/*` | HTTP + HTML | Dashboard, safety API, policy controls |
+| `/mcp/*` | MCP Streamable HTTP | Tool access for Claude Code and MCP clients |
 
-Both modes provide the same four pillars: cost tracking, safety enforcement, provenance, and governance.
+All three surfaces share one `ProxyState` — cost tracking, safety signals, decisions, and policy are live across every interface simultaneously.
 
-## Four Pillars
+## Components
 
-```
-                    ┌─────────────────────┐
-                    │    GOVERNANCE        │  X-AEP-Entity, Classification, Consent
-                    │    (who & what)      │
-                    ├─────────────────────┤
-                    │    PROVENANCE        │  Sources, citations, trace IDs
-                    │    (where from)      │
-                    ├─────────────────────┤
-                    │    SAFETY            │  PII, toxicity, agent threats → PASS/FLAG/BLOCK
-                    │    (is it safe)      │
-                    ├─────────────────────┤
-                    │    COST              │  Tokens, model pricing, cumulative spend
-                    │    (what it costs)   │
-                    └─────────────────────┘
-```
+### Proxy (`proxy/app.py`)
+
+- Intercepts all LLM traffic at the network level (OpenAI-compatible `/v1/*`)
+- Runs safety detectors on input and output
+- Enforces PASS/FLAG/BLOCK decisions
+- Tracks cost per call via `CostTracker`
+- Optionally signs verdicts (Ed25519 + Merkle chain via `attestation.py`)
+- Serves the dashboard at `/aep/` and state API at `/aep/api/*`
+
+### Dashboard (`dashboard/templates/index.html`)
+
+A dark-themed local web UI that auto-refreshes every 2 seconds.
+
+**Developer view:**
+- Individual call log with safety signals and cost per call
+- Call timeline, governance context, enforcement decisions
+
+**Executive/CISO view:**
+- Enforcement coverage %, threats blocked, compliance status
+- Safety breakdown (PII / threats / toxicity / anomalies)
+- Cost attribution by entity
+
+**Policy controls:**
+- Per-detector checkboxes (enable/disable each detector individually)
+- Trust Engine category toggles (finance, iot, software, web, program R-Judge dimensions)
+- Safety on/off master toggle in the header
+
+**Setup wizard:**
+- First-run overlay shown when `localStorage` has no `safeclaw-setup-done` flag and call count is 0
+- Two-option flow: BYOK (paste API key) or AceTeam hosted ($5 credit, coming soon)
+- Step 2 shows the `OPENAI_BASE_URL` export command and Claude Code MCP JSON config to copy
+
+### MCP Gateway (`mcp_gateway.py`)
+
+- FastMCP Streamable HTTP server mounted at `/mcp/` on the proxy
+- Shares `ProxyState` with the proxy via closure
+- Lifespan task group wired into the parent Starlette app's lifespan context
+- Optional dependency: only active when `fastmcp` is installed (`pip install aceteam-aep[mcp]`)
+
+**Tier 1 tools (always available locally):**
+
+| Tool | Description |
+|------|-------------|
+| `check_safety` | Check text for safety issues. Returns PASS/FLAG/BLOCK with signal details. |
+| `get_safety_status` | Session metrics: calls, signals, cost, safety enabled state, policy. |
+| `set_safety_policy` | Toggle detectors on/off or update policy thresholds. |
+| `get_cost_summary` | Cost breakdown: total, per-call (last 10), by model, savings from blocks. |
+
+### Safety Detectors (`safety/`)
+
+All detectors implement `check(*, input_text, output_text, call_id, **kwargs) -> list[SafetySignal]`.
+
+| Detector | Model | What it catches |
+|----------|-------|----------------|
+| `AgentThreatDetector` | Regex (11 patterns) | Subprocess, socket, port scan, reverse shell, credential access |
+| `PiiDetector` | iiiorg/piiranha (~110MB) + regex fallback | SSN, credit card, email, phone, IP address |
+| `CostAnomalyDetector` | Statistical (no ML) | Cost spikes >Nx session average |
+| `ContentSafetyDetector` | s-nlp/roberta_toxicity (~125MB) | Toxic, harmful, unsafe content |
+| `FerpaDetector` | Regex patterns | Student IDs, grades, transcripts, financial aid |
+| `TrustEngineDetector` | Multi-perspective LLM | Calibrated confidence across configurable dimensions |
+
+### Enforcement (`enforcement.py`)
+
+- Policy-driven: YAML config → `DetectorPolicy` per detector
+- Priority: per-detector action override → severity fallback → default action
+- `build_detectors_from_policy()` creates detector instances from a policy YAML
+- `evaluate(signals, policy)` → `EnforcementDecision` with action (pass/flag/block) and reason
+
+### CLI (`proxy/cli.py`)
+
+| Command | Description |
+|---------|-------------|
+| `proxy` | Start the gateway. Prints LLM proxy URL, dashboard URL, and MCP URL on startup. |
+| `wrap` | Wrap any command with AEP proxy — sets `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` in the child process env. |
+| `keygen` | Generate Ed25519 keypair (`aep.key` / `aep.pub`) for verdict signing. |
+| `verify` | Verify a Merkle audit chain JSONL file against a public key. |
+| `mcp-server` | Stdio MCP server (legacy — for non-HTTP MCP clients). |
 
 ## Module Map
 
 ```
 src/aceteam_aep/
-├── wrap.py              # SDK wrapper (wrap mode) — AepSession, AepSource, monkey-patching
+├── wrap.py              # SDK wrapper (wrap mode) — AepSession, monkey-patching
 ├── proxy/
-│   ├── app.py           # Starlette ASGI app (proxy mode) — ProxyState, request handling
-│   ├── cli.py           # CLI: aceteam-aep proxy, aceteam-aep wrap
+│   ├── app.py           # Starlette ASGI app — ProxyState, request handling, route mounting
+│   ├── cli.py           # CLI: proxy, wrap, keygen, verify, mcp-server
 │   ├── headers.py       # X-AEP-* header parsing, building, stripping
 │   └── streaming.py     # SSE stream interception for streaming responses
+├── mcp_gateway.py       # FastMCP Streamable HTTP gateway — 4 Tier 1 tools
 ├── safety/
 │   ├── base.py          # SafetySignal, DetectorRegistry — detector interface
-│   ├── pii.py           # PII detector (HuggingFace piiranha model + regex fallback)
+│   ├── pii.py           # PII detector (HuggingFace piiranha + regex fallback)
 │   ├── content.py       # Content safety (HuggingFace toxicity classifier)
-│   ├── cost_anomaly.py  # Cost anomaly detection (statistical, no ML)
-│   ├── agent_threat.py  # Agent threat patterns (regex: port scans, subprocess, credential access)
-│   ├── ferpa.py         # FERPA education records detector (student IDs, grades, transcripts)
-│   └── trust_engine.py  # Trust Engine — multi-perspective + ensemble + external judge service
-├── enforcement.py       # EnforcementPolicy, evaluate(), discover_policy(), build_detectors_from_policy()
-├── config.py            # Unified YAML config: proxy, enforcement, budget (CLI > env > YAML > defaults)
-├── feedback.py          # Signal feedback loop: verdicts → threshold recommendations
-├── instrument.py        # Global SDK patching: instrument() patches OpenAI/Anthropic at module level
+│   ├── cost_anomaly.py  # Cost anomaly detection (statistical)
+│   ├── agent_threat.py  # Agent threat patterns (11 regex patterns)
+│   ├── ferpa.py         # FERPA education records detector
+│   └── trust_engine.py  # Trust Engine — multi-perspective + ensemble + external judge
+├── enforcement.py       # EnforcementPolicy, evaluate(), build_detectors_from_policy()
 ├── attestation.py       # Ed25519 signed verdicts + Merkle audit chains
+├── config.py            # Unified YAML config: proxy, enforcement, budget
+├── feedback.py          # Signal feedback loop: verdicts → threshold recommendations
+├── instrument.py        # Global SDK patching: instrument() patches OpenAI/Anthropic
 ├── provenance/          # Source attribution: extractor + tracker
 ├── costs.py             # CostTracker, CostNode — per-call cost accounting
 ├── spans.py             # SpanTracker — execution trace recording
 ├── types.py             # Usage, shared types
 ├── dashboard/
-│   └── templates/       # HTML dashboard (developer + executive views, safety toggle, review buttons)
+│   └── templates/       # HTML dashboard (developer + executive views, policy controls, setup wizard)
 └── __init__.py          # Public API
 ```
-
-## Wrap Mode
-
-```python
-from aceteam_aep import wrap
-client = wrap(openai.OpenAI())
-```
-
-The `wrap()` function:
-1. Creates an `AepSession` attached as `client.aep`
-2. Monkey-patches `client.chat.completions.create()` (and async variant)
-3. For each call:
-   a. **Pre-flight check** — run detectors on input text. If BLOCK, raise `AepPreflightBlock` (request never sent)
-   b. **Forward call** to the real OpenAI/Anthropic API
-   c. **Post-flight** — extract usage, run detectors on output text, record cost + span + signals
-   d. **Enforce** — evaluate signals against policy → PASS/FLAG/BLOCK decision
-
-### Pre-flight Blocking
-
-```
-Input text → Detectors → Signals → Policy evaluation
-                                         │
-                                    ┌────┴────┐
-                                    │  BLOCK  │ → AepPreflightBlock raised, $0 cost
-                                    └─────────┘
-                                    │  PASS   │ → Continue to API call
-                                    └─────────┘
-```
-
-## Proxy Mode
-
-```bash
-aceteam-aep proxy --port 8899 --host 0.0.0.0
-```
-
-The proxy:
-1. Starts a Starlette ASGI server
-2. Intercepts all `/v1/*` requests (OpenAI-compatible API)
-3. For each request:
-   a. Parse body (extract messages/input text)
-   b. Parse X-AEP-* governance headers
-   c. **Pre-flight** — run detectors on input. If BLOCK, return HTTP 400 (request never forwarded)
-   d. Strip X-AEP-* headers before forwarding upstream
-   e. Forward to target API (OpenAI, Anthropic, etc.)
-   f. **Post-flight** — run detectors on response, record cost + signals
-   g. Add X-AEP-* response headers (cost, enforcement, call_id, classification, trace_id)
-4. Serves dashboard at `/aep/` and state API at `/aep/api/state`
-
-## Safety Detectors
-
-All detectors implement the same interface:
-
-```python
-class MyDetector:
-    name = "my_detector"
-
-    def check(self, *, input_text: str, output_text: str, call_id: str, **kwargs) -> list[SafetySignal]:
-        # Return list of SafetySignal if issues detected, empty list if clean
-        return []
-```
-
-Built-in detectors:
-
-| Detector | Model | What it catches |
-|----------|-------|----------------|
-| `PiiDetector` | iiiorg/piiranha (110MB) + regex fallback | SSN, email, phone, credit card, IP address |
-| `ContentSafetyDetector` | s-nlp/roberta_toxicity (125MB) | Toxic, harmful, unsafe content |
-| `CostAnomalyDetector` | Statistical (no ML) | Cost spikes >Nx session average |
-| `AgentThreatDetector` | Regex patterns | Port scans, subprocess, socket, credential access |
-| `FerpaDetector` | Regex patterns | Student IDs, grades, transcripts, financial aid (FERPA) |
-| `TrustEngineDetector` | Multi-perspective LLM | Calibrated confidence across configurable dimensions |
-
-## Enforcement Policy
-
-Signals are evaluated against a configurable policy:
-
-```yaml
-# aep-policy.yaml
-default_action: flag
-block_on: [high]
-flag_on: [medium]
-detectors:
-  pii:
-    action: block
-    threshold: 0.8
-  agent_threat:
-    action: block
-```
-
-Policy discovery chain: explicit argument → `AEP_POLICY` env var → file walk (aep-policy.yaml) → built-in default.
-
-## Provenance
-
-The SDK tracks data sources via `client.aep.add_source()`:
-
-```python
-client.aep.add_source("file:///data/report.pdf", kind="file", label="Q1 Report")
-client.aep.add_source("https://api.example.com/v1/data", kind="api", label="Customer API")
-
-# After calls
-print(client.aep.sources)            # all sources
-print(client.aep.get_citations("call-123"))  # sources for a specific call
-print(client.aep.provenance_summary) # summary with counts by kind
-```
-
-The proxy tracks provenance via `X-AEP-Sources` and `X-AEP-Trace-Id` headers.
-
-## Governance Headers
-
-Both modes support governance context:
-
-| Header | Purpose | Example |
-|--------|---------|---------|
-| `X-AEP-Entity` | Organization/agent identity | `org:acme-corp` |
-| `X-AEP-Classification` | Data sensitivity level | `confidential` |
-| `X-AEP-Consent` | Data processing consent | `analytics=true,training=false` |
-| `X-AEP-Budget` | Cost budget cap (USD) | `10.00` |
-| `X-AEP-Sources` | Data sources used | `file:///data/report.pdf` |
-| `X-AEP-Trace-Id` | Distributed trace correlation | `workflow-1234` |
-
-In wrap mode, set via env vars: `AEP_ENTITY`, `AEP_CLASSIFICATION`, etc.
-In proxy mode, send as HTTP headers on each request.
-
-## Docker Deployment
-
-Pre-built image: `ghcr.io/aceteam-ai/aep-proxy:latest`
-
-- Python 3.12 slim base
-- Safety models pre-downloaded (~235MB)
-- Binds to `0.0.0.0:8899`
-- Healthcheck on `/aep/`
-- Entrypoint: `aceteam-aep proxy`
-
-Published on tag push via GitHub Actions.
 
 ## Trust Engine
 
@@ -205,10 +137,10 @@ Multi-perspective safety evaluation with calibrated confidence scoring. Three mo
 
 Dimensions are safety perspectives. Two sets:
 
-- **Default**: pii, toxicity, agent_threat, policy_compliance, irreversibility
-- **R-Judge domains**: finance, iot, software, web, program (from SJTU R-Judge benchmark, EMNLP 2024)
+- **Default**: `pii`, `toxicity`, `agent_threat`, `policy_compliance`, `irreversibility`
+- **R-Judge domains**: `finance`, `iot`, `software`, `web`, `program` (SJTU R-Judge benchmark, EMNLP 2024)
 
-Dimensions are toggleable per policy YAML. The external judge service (AdaExtract2 `judge_service.py`) wraps Gustavo's specialist prompts as a Flask API.
+Dimensions are toggleable per policy YAML. The external judge service (AdaExtract2 `judge_service.py`) wraps specialist prompts as a Flask API.
 
 ## Runtime Safety Toggle
 
@@ -225,17 +157,34 @@ curl -X POST localhost:8899/aep/api/safety -d '{"policy": {"default_action": "bl
 curl localhost:8899/aep/api/safety
 ```
 
-Dashboard has a toggle switch in the header. State is reflected in `/aep/api/state` as `safety_enabled`.
+The dashboard has a master toggle switch in the header. Per-detector and per-category checkboxes allow fine-grained control without restart.
 
 ## Signal Feedback Loop
 
-Operators mark flagged signals as confirmed (true positive) or dismissed (false positive):
+Operators mark flagged signals as confirmed (true positive) or dismissed (false positive) via the dashboard review buttons or `POST /aep/api/feedback`:
 
 ```
 POST /aep/api/feedback → JSONL store → analyze FP rate → recommend threshold → apply to YAML
 ```
 
-The system uses the 90th percentile of dismissed scores (capped below lowest confirmed) to suggest thresholds. Needs 5+ verdicts per detector.
+The system uses the 90th percentile of dismissed scores (capped below the lowest confirmed score) to suggest thresholds. Requires 5+ verdicts per detector.
+
+## Attestation
+
+Optional Ed25519 signed verdicts with Merkle chaining for tamper-evident audit trails:
+
+```bash
+# Generate keypair
+aceteam-aep keygen --output ./keys
+
+# Start proxy with signing
+aceteam-aep proxy --sign-key ./keys/aep.key
+
+# Verify chain
+aceteam-aep verify --pub-key ./keys/aep.pub --chain audit.jsonl
+```
+
+Each verdict in the chain contains the previous chain hash, so any tampering is detectable.
 
 ## Vertical Policy Templates
 
@@ -250,3 +199,25 @@ Pre-built policies in `policies/`:
 | `startup.yaml` | 0.8 | 10x | flag |
 | `clawcamp.yaml` | 0.6 | 5x | flag (5 R-Judge categories) |
 | `safety-off.yaml` | — | — | pass (all detectors disabled) |
+
+## Docker Deployment
+
+Pre-built image: `ghcr.io/aceteam-ai/aep-proxy:latest`
+
+- Python 3.12 slim base
+- Safety models pre-downloaded (~235MB)
+- Binds to `0.0.0.0:8899`
+- Healthcheck on `/aep/`
+- Entrypoint: `aceteam-aep proxy`
+
+Published on tag push via GitHub Actions.
+
+## Integration Points
+
+| Client | How to integrate |
+|--------|-----------------|
+| Claude Code | MCP config → `http://localhost:8899/mcp/` (see `docs/engineering/mcp-integration.md`) |
+| OpenClaw / SafeClaw | `export OPENAI_BASE_URL=http://localhost:8899/v1` |
+| Any Python agent | `aceteam-aep wrap -- python my_agent.py` |
+| Docker sidecar | `OPENAI_BASE_URL=http://aep-proxy:8899/v1` in compose |
+| AceTeam Platform | Gateway proxies Tier 2+ MCP calls to backend (planned) |

--- a/docs/engineering/mcp-integration.md
+++ b/docs/engineering/mcp-integration.md
@@ -1,0 +1,103 @@
+# MCP Integration Guide
+
+The AEP Gateway exposes safety and cost tools as MCP tools via FastMCP's Streamable HTTP transport, mounted at `/mcp/` on the proxy. Everything runs on one port — the same process serving the LLM proxy and dashboard also serves MCP.
+
+## Quick Start
+
+**Step 1: Start the gateway**
+
+```bash
+pip install aceteam-aep[all]
+aceteam-aep proxy
+```
+
+**Step 2: Add to Claude Code config**
+
+```json
+{
+  "mcpServers": {
+    "aceteam": {
+      "type": "streamable-http",
+      "url": "http://localhost:8899/mcp/"
+    }
+  }
+}
+```
+
+The setup wizard in the dashboard (shown on first visit) provides this config snippet with a copy button.
+
+## Available Tools
+
+### Tier 1 — Local (always available)
+
+These tools work without an AceTeam account. They share state with the proxy — signals checked via `check_safety` appear in the dashboard.
+
+| Tool | Description |
+|------|-------------|
+| `check_safety` | Check text for safety issues. Returns PASS/FLAG/BLOCK with signal details, severity, and score. |
+| `get_safety_status` | Session metrics: call count, signal count, total cost, blocked calls, current policy. |
+| `set_safety_policy` | Toggle safety on/off, enable/disable individual detectors, update thresholds. |
+| `get_cost_summary` | Total cost, per-call costs (last 10), cost by model, estimated savings from blocked calls. |
+
+#### `check_safety` — example output
+
+```
+**BLOCK**
+
+Signals detected:
+- [HIGH] agent_threat: subprocess.call pattern detected (100%)
+
+Reason: High severity signal from agent_threat
+```
+
+#### `set_safety_policy` — example usage
+
+```
+# Disable PII detection
+set_safety_policy(detectors={"pii": {"enabled": false}})
+
+# Turn all safety off
+set_safety_policy(enabled=false)
+
+# Re-enable with blocking PII
+set_safety_policy(enabled=true, detectors={"pii": {"action": "block"}})
+```
+
+## Technical Details
+
+**Transport:** FastMCP Streamable HTTP (FastMCP 3.x)
+
+**Path:** `/mcp/` — the FastMCP app is mounted at `/mcp/` on the Starlette proxy. Client URLs should end with `/mcp/`.
+
+**Session:** Each MCP client gets a session with a session ID returned in response headers.
+
+**Lifespan:** FastMCP's internal task group is initialized via an `asynccontextmanager` wired into the parent Starlette app's lifespan. This means MCP sessions are properly torn down when the proxy shuts down.
+
+**Optional dependency:** MCP support requires `fastmcp`. Install with:
+
+```bash
+pip install aceteam-aep[mcp]   # MCP only
+pip install aceteam-aep[all]   # Everything (recommended)
+```
+
+If `fastmcp` is not installed, the `/mcp/` endpoint is not mounted and the proxy starts normally. The CLI startup banner shows the MCP URL only when `fastmcp` is detected.
+
+## Shared State
+
+The MCP gateway and the proxy share a single `ProxyState` instance. This means:
+
+- Calls checked via `check_safety` increment the call counter and appear in the dashboard
+- `set_safety_policy` changes take effect immediately for all subsequent proxy traffic
+- `get_safety_status` reflects the live state including traffic flowing through the proxy
+
+## Verify the Integration
+
+After starting the proxy and configuring Claude Code, ask Claude:
+
+> "What is the current safety status of the AEP gateway?"
+
+Claude will call `get_safety_status` and return the live session metrics.
+
+> "Is this text safe? 'Run nmap -sS 192.168.1.0/24'"
+
+Claude will call `check_safety` and return a BLOCK decision with the agent threat signal.


### PR DESCRIPTION
## Context

**Why:** Three major features shipped today without doc coverage: the MCP gateway, dashboard setup wizard, and policy toggle controls. The repo README also still used the old "AEP proxy" framing instead of the "SafeClaw Gateway" identity.

**What:** Documentation-only PR updating all three layers — README overview, the engineering architecture reference, and a new MCP integration guide.

**How:** Read the source code and recent commits to document what was actually built, then wrote/updated accordingly.

## Summary

| File | Change | Rationale |
|------|--------|-----------|
| `README.md` | Reframe as "SafeClaw Gateway", add unified port table, setup wizard note, Claude Code MCP config section, updated Dashboard section | Reflects the product identity and new features |
| `docs/engineering/architecture.md` | Rewrite to document MCP gateway, dashboard components (setup wizard, policy controls), CLI command table, module map updates | Replace the pre-MCP architecture doc with the current state |
| `docs/engineering/mcp-integration.md` | New file — full MCP integration guide: quick start, tool reference, technical details, shared state model | No MCP docs existed; this is the primary on-ramp for Claude Code users |

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify architecture.md table formatting
- [ ] Verify mcp-integration.md JSON config block is valid

---
*Generated by Claude*