### PR TITLE
feat: feedback loop — deny → embed → auto-block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dashboard = ["uvicorn>=0.30", "jinja2>=3.1", "starlette>=0.38"]
 proxy = ["aceteam-aep[dashboard]"]
 mcp = ["fastmcp>=2.0"]
 yaml = ["pyyaml>=6.0"]
-all = ["aceteam-aep[xai,ollama,safety,dashboard,proxy,yaml,mcp]"]
+feedback = ["lancedb>=0.30"]
+all = ["aceteam-aep[xai,ollama,safety,dashboard,proxy,yaml,mcp,feedback]"]
 dev = [
     "aceteam-aep[all]",
     "httpx>=0.28",

--- a/src/aceteam_aep/judge_service.py
+++ b/src/aceteam_aep/judge_service.py
@@ -47,40 +47,51 @@ class FeedbackStore:
     """Vector-backed feedback store using LanceDB for semantic similarity search."""
 
     def __init__(self, db_path: str = "~/.config/aceteam-aep/feedback.lance") -> None:
+        import threading
+
         self._db: Any = None
         self._table: Any = None
         self._db_path = os.path.expanduser(db_path)
         self._schema: Any = None
+        self._lock = threading.Lock()
 
     def _ensure_db(self) -> None:
         if self._db is not None:
             return
-        try:
-            import lancedb
-            from lancedb.embeddings import get_registry
-            from lancedb.pydantic import LanceModel, Vector
+        with self._lock:
+            if self._db is not None:
+                return
+            if not os.environ.get("OPENAI_API_KEY"):
+                log.warning(
+                    "OPENAI_API_KEY not set — feedback embeddings will fail. "
+                    "The feedback feature requires OPENAI_API_KEY even with alternative LLM backends."
+                )
+            try:
+                import lancedb
+                from lancedb.embeddings import get_registry
+                from lancedb.pydantic import LanceModel, Vector
 
-            openai_embed = get_registry().get("openai").create(name="text-embedding-3-small")
+                openai_embed = get_registry().get("openai").create(name="text-embedding-3-small")
 
-            class FeedbackEntry(LanceModel):
-                text: str = openai_embed.SourceField()
-                vector: Vector(1536) = openai_embed.VectorField()  # type: ignore[valid-type]
-                verdict: str
-                reason: str
-                risk: str
-                confidence: float
-                timestamp: float
+                class FeedbackEntry(LanceModel):
+                    text: str = openai_embed.SourceField()
+                    vector: Vector(1536) = openai_embed.VectorField()  # type: ignore[valid-type]
+                    verdict: str
+                    reason: str
+                    risk: str
+                    confidence: float
+                    timestamp: float
 
-            self._schema = FeedbackEntry
-            self._db = lancedb.connect(self._db_path)
-            self._table = self._db.create_table("feedback", schema=FeedbackEntry, exist_ok=True)
-        except ImportError:
-            log.info(
-                "lancedb not installed — feedback store disabled. "
-                "Install with: pip install aceteam-aep[feedback]"
-            )
-        except Exception as e:
-            log.warning("Failed to initialize feedback store: %s", e)
+                self._schema = FeedbackEntry
+                self._db = lancedb.connect(self._db_path)
+                self._table = self._db.create_table("feedback", schema=FeedbackEntry, exist_ok=True)
+            except ImportError:
+                log.info(
+                    "lancedb not installed — feedback store disabled. "
+                    "Install with: pip install aceteam-aep[feedback]"
+                )
+            except Exception as e:
+                log.warning("Failed to initialize feedback store: %s", e)
 
     def add(
         self,
@@ -114,9 +125,12 @@ class FeedbackStore:
         if self._table is None or self._table.count_rows() == 0:
             return []
         try:
-            results = self._table.search(query).limit(limit).to_list()
+            fetch_limit = limit * 5 if risk else limit
+            results = self._table.search(query).limit(fetch_limit).to_list()
             if risk:
-                results = [r for r in results if r.get("risk") == risk]
+                results = [r for r in results if r.get("risk") == risk][:limit]
+            else:
+                results = results[:limit]
             return results
         except Exception as e:
             log.warning("Feedback search failed: %s", e)
@@ -213,13 +227,13 @@ def _build_prompt(
         if denied:
             feedback_section += "\n\n**Previous human decisions on similar actions:**\n"
             for d in denied:
-                feedback_section += f'- DENIED: "{d["text"][:150]}" — Reason: {d["reason"]}\n'
+                feedback_section += f'- DENIED: "{d["text"][:150]}" — Reason: {str(d.get("reason", ""))[:200]}\n'
             feedback_section += "\nWeight these prior human decisions heavily in your evaluation.\n"
 
         if approved:
             feedback_section += "\n**Previously approved safe actions:**\n"
             for a in approved:
-                feedback_section += f'- APPROVED: "{a["text"][:150]}" — Reason: {a["reason"]}\n'
+                feedback_section += f'- APPROVED: "{a["text"][:150]}" — Reason: {str(a.get("reason", ""))[:200]}\n'
 
     return f"{specialist}{feedback_section}\n\nEvaluate this agent interaction:\n\n{text}"
 
@@ -426,17 +440,35 @@ def create_judge_app(
         except Exception:
             return JSONResponse({"error": "invalid JSON"}, status_code=400)
         text = body.get("text", "")
-        verdict = body.get("verdict", "")
-        if not text or not verdict:
+        if not text:
             return JSONResponse(
                 {"error": "missing 'text' and 'verdict' fields"}, status_code=400
             )
+
+        # Validate verdict
+        valid_verdicts = {"approved", "denied"}
+        verdict = body.get("verdict", "").lower().strip()
+        if verdict not in valid_verdicts:
+            return JSONResponse(
+                {"error": f"verdict must be one of: {valid_verdicts}"}, status_code=400
+            )
+
+        # Validate and cap confidence
+        confidence = body.get("confidence", 0.0)
+        try:
+            confidence = max(0.0, min(1.0, float(confidence)))
+        except (ValueError, TypeError):
+            confidence = 0.0
+
+        # Truncate reason to prevent prompt injection via long payloads
+        reason = str(body.get("reason", ""))[:200]
+
         feedback_store.add(
             text=text,
             verdict=verdict,
-            reason=body.get("reason", ""),
+            reason=reason,
             risk=body.get("risk", ""),
-            confidence=body.get("confidence", 0.0),
+            confidence=confidence,
         )
         return JSONResponse({"status": "stored", "total": feedback_store.count})
 

--- a/src/aceteam_aep/judge_service.py
+++ b/src/aceteam_aep/judge_service.py
@@ -31,12 +31,103 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+
+# ── Feedback Store ──
+
+
+class FeedbackStore:
+    """Vector-backed feedback store using LanceDB for semantic similarity search."""
+
+    def __init__(self, db_path: str = "~/.config/aceteam-aep/feedback.lance") -> None:
+        self._db: Any = None
+        self._table: Any = None
+        self._db_path = os.path.expanduser(db_path)
+        self._schema: Any = None
+
+    def _ensure_db(self) -> None:
+        if self._db is not None:
+            return
+        try:
+            import lancedb
+            from lancedb.embeddings import get_registry
+            from lancedb.pydantic import LanceModel, Vector
+
+            openai_embed = get_registry().get("openai").create(name="text-embedding-3-small")
+
+            class FeedbackEntry(LanceModel):
+                text: str = openai_embed.SourceField()
+                vector: Vector(1536) = openai_embed.VectorField()  # type: ignore[valid-type]
+                verdict: str
+                reason: str
+                risk: str
+                confidence: float
+                timestamp: float
+
+            self._schema = FeedbackEntry
+            self._db = lancedb.connect(self._db_path)
+            self._table = self._db.create_table("feedback", schema=FeedbackEntry, exist_ok=True)
+        except ImportError:
+            log.info(
+                "lancedb not installed — feedback store disabled. "
+                "Install with: pip install aceteam-aep[feedback]"
+            )
+        except Exception as e:
+            log.warning("Failed to initialize feedback store: %s", e)
+
+    def add(
+        self,
+        text: str,
+        verdict: str,
+        reason: str = "",
+        risk: str = "",
+        confidence: float = 0.0,
+    ) -> None:
+        self._ensure_db()
+        if self._table is None:
+            return
+        try:
+            self._table.add(
+                [
+                    {
+                        "text": text,
+                        "verdict": verdict,
+                        "reason": reason,
+                        "risk": risk,
+                        "confidence": confidence,
+                        "timestamp": time.time(),
+                    }
+                ]
+            )
+        except Exception as e:
+            log.warning("Failed to store feedback: %s", e)
+
+    def search(self, query: str, risk: str | None = None, limit: int = 3) -> list[dict]:
+        self._ensure_db()
+        if self._table is None or self._table.count_rows() == 0:
+            return []
+        try:
+            results = self._table.search(query).limit(limit).to_list()
+            if risk:
+                results = [r for r in results if r.get("risk") == risk]
+            return results
+        except Exception as e:
+            log.warning("Feedback search failed: %s", e)
+            return []
+
+    @property
+    def count(self) -> int:
+        self._ensure_db()
+        if self._table is None:
+            return 0
+        return self._table.count_rows()
 
 # ── Risk-Type Specialists (Gustavo's approach, multi_specialist_approach branch) ──
 
@@ -108,9 +199,29 @@ JUDGE_SYSTEM = (
 )
 
 
-def _build_prompt(risk_key: str, text: str) -> str:
+def _build_prompt(
+    risk_key: str, text: str, feedback_store: FeedbackStore | None = None
+) -> str:
     specialist = RISK_SPECIALISTS.get(risk_key, "")
-    return f"{specialist}\n\nEvaluate this agent interaction:\n\n{text}"
+
+    feedback_section = ""
+    if feedback_store:
+        similar = feedback_store.search(text, risk=risk_key, limit=3)
+        denied = [f for f in similar if f.get("verdict") == "denied"]
+        approved = [f for f in similar if f.get("verdict") == "approved"]
+
+        if denied:
+            feedback_section += "\n\n**Previous human decisions on similar actions:**\n"
+            for d in denied:
+                feedback_section += f'- DENIED: "{d["text"][:150]}" — Reason: {d["reason"]}\n'
+            feedback_section += "\nWeight these prior human decisions heavily in your evaluation.\n"
+
+        if approved:
+            feedback_section += "\n**Previously approved safe actions:**\n"
+            for a in approved:
+                feedback_section += f'- APPROVED: "{a["text"][:150]}" — Reason: {a["reason"]}\n'
+
+    return f"{specialist}{feedback_section}\n\nEvaluate this agent interaction:\n\n{text}"
 
 
 def _parse_response(response_text: str) -> dict[str, Any]:
@@ -139,11 +250,12 @@ def _call_judge(
     model: str,
     base_url: str,
     api_key: str,
+    feedback_store: FeedbackStore | None = None,
 ) -> dict[str, Any]:
     """Call a single risk specialist. Designed to run in a thread."""
     import httpx
 
-    prompt = _build_prompt(risk_key, text)
+    prompt = _build_prompt(risk_key, text, feedback_store=feedback_store)
     start = time.monotonic()
     try:
         resp = httpx.post(
@@ -186,6 +298,7 @@ def evaluate_text(
     model: str = "gpt-4o-mini",
     base_url: str | None = None,
     api_key: str | None = None,
+    feedback_store: FeedbackStore | None = None,
 ) -> dict[str, Any]:
     """Run risk specialists in parallel and return aggregated verdict.
 
@@ -196,6 +309,7 @@ def evaluate_text(
         model: LLM model for judging.
         base_url: OpenAI-compatible API base URL.
         api_key: API key.
+        feedback_store: Optional FeedbackStore for few-shot injection.
     """
     if api_key is None:
         import os
@@ -221,7 +335,9 @@ def evaluate_text(
 
     with ThreadPoolExecutor(max_workers=len(active_risks)) as pool:
         futures = {
-            pool.submit(_call_judge, risk, text, model, target, api_key): risk
+            pool.submit(
+                _call_judge, risk, text, model, target, api_key, feedback_store
+            ): risk
             for risk in active_risks
         }
         for future in as_completed(futures):
@@ -273,6 +389,8 @@ def create_judge_app(
     from starlette.responses import JSONResponse
     from starlette.routing import Route
 
+    feedback_store = FeedbackStore()
+
     async def judge_handler(request: Request) -> JSONResponse:
         try:
             body = await request.json()
@@ -290,6 +408,7 @@ def create_judge_app(
             model=model,
             base_url=base_url,
             api_key=api_key,
+            feedback_store=feedback_store,
         )
         return JSONResponse(result)
 
@@ -301,10 +420,37 @@ def create_judge_app(
             "domain_risk_mapping": DOMAIN_RISKS,
         })
 
-    return Starlette(routes=[
-        Route("/judge", judge_handler, methods=["POST"]),
-        Route("/health", health, methods=["GET"]),
-    ])
+    async def feedback_handler(request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "invalid JSON"}, status_code=400)
+        text = body.get("text", "")
+        verdict = body.get("verdict", "")
+        if not text or not verdict:
+            return JSONResponse(
+                {"error": "missing 'text' and 'verdict' fields"}, status_code=400
+            )
+        feedback_store.add(
+            text=text,
+            verdict=verdict,
+            reason=body.get("reason", ""),
+            risk=body.get("risk", ""),
+            confidence=body.get("confidence", 0.0),
+        )
+        return JSONResponse({"status": "stored", "total": feedback_store.count})
+
+    async def feedback_history(request: Request) -> JSONResponse:
+        return JSONResponse({"total": feedback_store.count})
+
+    return Starlette(
+        routes=[
+            Route("/judge", judge_handler, methods=["POST"]),
+            Route("/health", health, methods=["GET"]),
+            Route("/feedback", feedback_handler, methods=["POST"]),
+            Route("/feedback/history", feedback_history, methods=["GET"]),
+        ]
+    )
 
 
 def run_judge_service(
@@ -320,6 +466,8 @@ def run_judge_service(
     print(f"\n  Judge Service (two-layer: risk detection + domain policies)")
     print(f"  {'─' * 50}")
     print(f"  Endpoint:  http://localhost:{port}/judge")
+    print(f"  Feedback:  http://localhost:{port}/feedback")
+    print(f"  History:   http://localhost:{port}/feedback/history")
     print(f"  Health:    http://localhost:{port}/health")
     print(f"  Model:     {model}")
     print(f"  Risks:     {', '.join(ALL_RISKS)}")

--- a/tests/test_judge_service.py
+++ b/tests/test_judge_service.py
@@ -118,6 +118,136 @@ class TestJudgeApp:
         assert resp.status_code == 400
 
 
+# ── Feedback Store tests (require OPENAI_API_KEY for embeddings) ─────────────
+
+
+class TestFeedbackStore:
+    """Test LanceDB-backed feedback store."""
+
+    @pytest.fixture(autouse=True)
+    def _require_api_key(self):
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OPENAI_API_KEY not set")
+
+    def test_store_and_search(self, tmp_path):
+        from aceteam_aep.judge_service import FeedbackStore
+
+        store = FeedbackStore(db_path=str(tmp_path / "feedback.lance"))
+        store.add(
+            text="Transfer $50,000 to offshore",
+            verdict="denied",
+            reason="Unauthorized",
+            risk="financial_loss",
+            confidence=0.6,
+        )
+        results = store.search("Wire money offshore")
+        assert len(results) >= 1
+        assert results[0]["verdict"] == "denied"
+
+    def test_empty_store(self, tmp_path):
+        from aceteam_aep.judge_service import FeedbackStore
+
+        store = FeedbackStore(db_path=str(tmp_path / "feedback-empty.lance"))
+        assert store.search("anything") == []
+        assert store.count == 0
+
+    def test_risk_filter(self, tmp_path):
+        from aceteam_aep.judge_service import FeedbackStore
+
+        store = FeedbackStore(db_path=str(tmp_path / "feedback-filter.lance"))
+        store.add(
+            text="Send SSH key",
+            verdict="denied",
+            reason="Credential leak",
+            risk="privacy_leakage",
+            confidence=0.7,
+        )
+        store.add(
+            text="Buy stocks",
+            verdict="denied",
+            reason="Unauthorized trade",
+            risk="financial_loss",
+            confidence=0.8,
+        )
+        results = store.search("Send private key to email", risk="privacy_leakage")
+        assert all(r["risk"] == "privacy_leakage" for r in results)
+
+
+class TestFewShotInjection:
+    """Test that past denials are injected into specialist prompts."""
+
+    @pytest.fixture(autouse=True)
+    def _require_api_key(self):
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OPENAI_API_KEY not set")
+
+    def test_denied_feedback_in_prompt(self, tmp_path):
+        from aceteam_aep.judge_service import FeedbackStore, _build_prompt
+
+        store = FeedbackStore(db_path=str(tmp_path / "feedback-inject.lance"))
+        store.add(
+            text="Transfer $50,000 offshore",
+            verdict="denied",
+            reason="Unauthorized transfer",
+            risk="financial_loss",
+            confidence=0.6,
+        )
+        prompt = _build_prompt("financial_loss", "Wire $30,000 to external", feedback_store=store)
+        assert "DENIED" in prompt
+        assert "Unauthorized" in prompt
+
+    def test_no_feedback_clean_prompt(self, tmp_path):
+        from aceteam_aep.judge_service import FeedbackStore, _build_prompt
+
+        store = FeedbackStore(db_path=str(tmp_path / "feedback-clean.lance"))
+        prompt = _build_prompt("financial_loss", "Wire money", feedback_store=store)
+        assert "DENIED" not in prompt
+
+
+class TestFeedbackHTTP:
+    """Test HTTP feedback endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _require_api_key(self):
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OPENAI_API_KEY not set")
+
+    def test_feedback_endpoint(self):
+        from starlette.testclient import TestClient
+
+        from aceteam_aep.judge_service import create_judge_app
+
+        app = create_judge_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/feedback",
+            json={
+                "text": "Test action",
+                "verdict": "denied",
+                "reason": "Test",
+                "risk": "financial_loss",
+                "confidence": 0.5,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "stored"
+
+        resp = client.get("/feedback/history")
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 1
+
+    def test_feedback_rejects_empty(self):
+        from starlette.testclient import TestClient
+
+        from aceteam_aep.judge_service import create_judge_app
+
+        app = create_judge_app()
+        client = TestClient(app)
+        resp = client.post("/feedback", json={})
+        assert resp.status_code == 400
+
+
 # ── Integration tests (require OPENAI_API_KEY) ──────────────────────────────
 
 


### PR DESCRIPTION
## Context

**Why** — When a human denies a flagged action, that decision should improve future evaluations. Currently each judge call is stateless — the same risky pattern gets flagged but never auto-blocked based on prior human decisions.

**What** — A feedback loop that stores human verdicts (deny/approve) in LanceDB with embeddings, then injects semantically similar past decisions as few-shot examples into specialist prompts.

**How** — `FeedbackStore` wraps LanceDB with OpenAI `text-embedding-3-small` embeddings. On each `evaluate_text()` call, similar past verdicts are retrieved and injected into the specialist prompt. Denied actions are weighted heavily ("Weight these prior human decisions heavily"), approved actions are shown as context.

## Summary

| Component | What | Why |
|-----------|------|-----|
| `FeedbackStore` class | LanceDB-backed vector store with add/search/count | Semantic similarity enables matching conceptually similar actions, not just keyword matches |
| `_build_prompt()` update | Injects past denials/approvals as few-shot examples | LLM sees prior human decisions, boosting confidence on similar actions |
| `POST /feedback` | HTTP endpoint to store verdicts | Proxy/dashboard can submit human decisions |
| `GET /feedback/history` | Returns total feedback count | Health monitoring |
| `feedback` optional dep | `lancedb>=0.30` in pyproject.toml | Graceful fallback when not installed |

## Test plan

| Group | Count | Coverage |
|-------|-------|----------|
| FeedbackStore unit | 3 | store+search, empty store, risk filtering |
| Few-shot injection | 2 | denied feedback in prompt, clean prompt without feedback |
| HTTP endpoints | 2 | POST /feedback stores, POST /feedback rejects empty |
| Existing tests | 22 | All passing, no regressions |

All 29 tests pass.

## Related

- Issue #77

---
*Generated by Claude*