### PR TITLE
Add transformers dependencies to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,15 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        # Shared libs manylinux/pip wheels expect at load time. Extend this list as needed.
+        # Pip binary wheels may need extra shared libs from the store at load time. The motivating
+        # case was manylinux/Linux (LD_LIBRARY_PATH + ld.so); Darwin uses dyld and DYLD_LIBRARY_PATH.
         pythonWheelRuntimeLibs = with pkgs; [
           stdenv.cc.cc.lib
           zlib
           openssl
           libffi
         ];
+        libPath = pkgs.lib.makeLibraryPath pythonWheelRuntimeLibs;
       in {
         devShells.default = pkgs.mkShell {
           packages = [
@@ -24,12 +26,23 @@
             pkgs.python312
           ];
 
-          # Makes the above store paths visible to ld.so when Python loads extension modules.
-          shellHook = ''
-            export UV_PYTHON="${pkgs.python312}/bin/python3"
-            export UV_PYTHON_PREFERENCE="only-system"
-            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath pythonWheelRuntimeLibs}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-          '';
+          shellHook =
+            ''
+              export UV_PYTHON="${pkgs.python312}/bin/python3"
+              export UV_PYTHON_PREFERENCE="only-system"
+            ''
+            + (
+              if pkgs.stdenv.isLinux then
+                ''
+                  export LD_LIBRARY_PATH="${libPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                ''
+              else if pkgs.stdenv.isDarwin then
+                ''
+                  export DYLD_LIBRARY_PATH="${libPath}''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+                ''
+              else
+                ""
+            );
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,13 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        # Shared libs manylinux/pip wheels expect at load time. Extend this list as needed.
+        pythonWheelRuntimeLibs = with pkgs; [
+          stdenv.cc.cc.lib
+          zlib
+          openssl
+          libffi
+        ];
       in {
         devShells.default = pkgs.mkShell {
           packages = [
@@ -17,9 +24,11 @@
             pkgs.python312
           ];
 
+          # Makes the above store paths visible to ld.so when Python loads extension modules.
           shellHook = ''
             export UV_PYTHON="${pkgs.python312}/bin/python3"
             export UV_PYTHON_PREFERENCE="only-system"
+            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath pythonWheelRuntimeLibs}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
           '';
         };
       });

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aceteam-aep"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Without these, you get errors like this when importing transformers

```
justin@aceteamvm:~/aceteam-aep$ uv run python
Python 3.12.12 (main, Oct  9 2025, 11:07:00) [GCC 15.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import transformers
Traceback (most recent call last):
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/numpy/_core/__init__.py", line 24, in <module>
    from . import multiarray
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/numpy/_core/multiarray.py", line 11, in <module>
    from . import _multiarray_umath, overrides
ImportError: libz.so.1: cannot open shared object file: No such file or directory

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/transformers/__init__.py", line 30, in <module>
    from . import dependency_versions_check
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/transformers/dependency_versions_check.py", line 16, in <module>
    from .utils.versions import require_version, require_version_core
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/transformers/utils/__init__.py", line 22, in <module>
    from .auto_docstring import (
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/transformers/utils/auto_docstring.py", line 32, in <module>
    from .generic import ModelOutput
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/transformers/utils/generic.py", line 32, in <module>
    import numpy as np
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/numpy/__init__.py", line 112, in <module>
    from numpy.__config__ import show_config
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/numpy/__config__.py", line 4, in <module>
    from numpy._core._multiarray_umath import (
  File "/home/justin/aceteam-aep/.venv/lib/python3.12/site-packages/numpy/_core/__init__.py", line 85, in <module>
    raise ImportError(msg) from exc
ImportError: 

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy C-extensions failed. This error can happen for
many reasons, often due to issues with your setup or how NumPy was
installed.

We have compiled some common reasons and troubleshooting tips at:

    https://numpy.org/devdocs/user/troubleshooting-importerror.html

Please note and check the following:

  * The Python version is: Python 3.12 from "/home/justin/aceteam-aep/.venv/bin/python3"
  * The NumPy version is: "2.4.3"

and make sure that they are the versions you expect.

Please carefully study the information and documentation linked above.
This is unlikely to be a NumPy issue but will be caused by a bad install
or environment on your machine.

Original error was: libz.so.1: cannot open shared object file: No such file or directory
```

I don't think this fixes it for the Docker container, where `transformers` seems to also fail to install