### PR TITLE
Add --debug flag to aceteam-aep proxy

### DIFF
--- a/src/aceteam_aep/config.py
+++ b/src/aceteam_aep/config.py
@@ -52,6 +52,7 @@ class ProxyConfig:
     target: str = "https://api.openai.com"
     dashboard: bool = True
     verbose: bool = False
+    debug: bool = False
 
     # Enforcement policy (built from enforcement section)
     policy: EnforcementPolicy = field(default_factory=EnforcementPolicy)
@@ -87,6 +88,7 @@ def load_config(
         target=proxy_section.get("target", "https://api.openai.com"),
         dashboard=proxy_section.get("dashboard", True),
         verbose=proxy_section.get("verbose", False),
+        debug=proxy_section.get("debug", False),
         max_per_session=budget_section.get("max_per_session"),
         max_per_call=budget_section.get("max_per_call"),
     )
@@ -109,6 +111,8 @@ def load_config(
         config.target = os.environ["AEP_TARGET"]
     if os.environ.get("AEP_LOG", "") in ("1", "true", "yes"):
         config.verbose = True
+    if os.environ.get("AEP_DEBUG", "") in ("1", "true", "yes"):
+        config.debug = True
 
     # AEP_POLICY env var overrides the enforcement section
     policy_path = os.environ.get("AEP_POLICY")
@@ -127,6 +131,8 @@ def load_config(
             config.dashboard = False
         if cli_overrides.get("policy"):
             config.policy = EnforcementPolicy.from_yaml(cli_overrides["policy"])
+        if cli_overrides.get("debug") is not None:
+            config.debug = cli_overrides["debug"]
 
     return config
 

--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -28,6 +28,7 @@ from ..safety.cost_anomaly import CostAnomalyDetector
 from ..spans import SpanTracker
 from ..types import Usage
 from .headers import build_response_headers, parse_aep_headers, strip_aep_headers
+from .logutil import configure_proxy_debug_logging
 from .redis_publisher import build_event, publish_event
 
 log = logging.getLogger(__name__)
@@ -234,6 +235,7 @@ def create_proxy_app(
     signer_id: str = "proxy:default",
     budget: float | None = None,
     budget_per_session: float | None = None,
+    debug: bool = False,
 ) -> Starlette:
     """Create the AEP proxy ASGI app."""
 
@@ -244,6 +246,10 @@ def create_proxy_app(
         budget=budget,
         budget_per_session=budget_per_session,
     )
+
+    # Enable debug logging if requested (see logutil; uvicorn/defaults drop DEBUG)
+    if debug:
+        configure_proxy_debug_logging()
 
     # Attestation engine (optional — enabled when sign_key is provided)
     attestation_engine = None
@@ -276,6 +282,14 @@ def create_proxy_app(
         call_id = uuid.uuid4().hex[:8]
         path = request.url.path
         body_bytes = await request.body()
+
+        # Debug logging for all requests (both input and output)
+        if debug:
+            try:
+                body = json.loads(body_bytes) if body_bytes else {}
+            except json.JSONDecodeError:
+                body = {}
+            log.debug("REQUEST %s %s %s: headers=%s, body=%s", call_id, request.method, path, dict(request.headers), body)
 
         # Parse request body
         try:
@@ -448,6 +462,7 @@ def create_proxy_app(
                 registry=state.registry,
                 policy=state.policy,
                 on_complete=on_stream_complete,
+                debug=debug,
             )
 
         # --- NON-STREAMING BRANCH ---
@@ -588,6 +603,20 @@ def create_proxy_app(
                 ),
             )
             resp_headers.update(attest_headers)
+
+        # Debug: log the response
+        if debug:
+            log.debug(
+                "RESPONSE %s %s %s: model=%s, input_tokens=%d, output_tokens=%d, status=%d, body=%s",
+                call_id,
+                request.method,
+                path,
+                model,
+                input_tokens,
+                output_tokens,
+                upstream_resp.status_code,
+                resp_data,
+            )
 
         return Response(
             content=upstream_resp.content,

--- a/src/aceteam_aep/proxy/cli.py
+++ b/src/aceteam_aep/proxy/cli.py
@@ -56,6 +56,8 @@ def _resolve_config(args: argparse.Namespace) -> object:
         cli_overrides["no_dashboard"] = True
     if getattr(args, "policy", None):
         cli_overrides["policy"] = args.policy
+    if getattr(args, "debug", False):
+        cli_overrides["debug"] = True
 
     return load_config(config_path, cli_overrides=cli_overrides)
 
@@ -103,6 +105,7 @@ def _run_proxy(args: argparse.Namespace) -> None:
 
     # Use unified config if --config provided, otherwise legacy args
     config_path = getattr(args, "config", None) or os.environ.get("AEP_CONFIG")
+    debug = getattr(args, "debug", False) or (config_path and getattr(_resolve_config(args), "debug", False))
     if config_path:
         cfg = _resolve_config(args)
         detectors = _build_detectors(args, cfg.policy)  # type: ignore[attr-defined]
@@ -111,6 +114,7 @@ def _run_proxy(args: argparse.Namespace) -> None:
             detectors=detectors,
             policy=cfg.policy,  # type: ignore[attr-defined]
             dashboard=cfg.dashboard,  # type: ignore[attr-defined]
+            debug=debug,
         )
         port = cfg.port  # type: ignore[attr-defined]
         host = cfg.host  # type: ignore[attr-defined]
@@ -130,6 +134,7 @@ def _run_proxy(args: argparse.Namespace) -> None:
             signer_id=signer_id,
             budget=getattr(args, "budget", None),
             budget_per_session=getattr(args, "budget_per_session", None),
+            debug=debug,
         )
         port = args.port or 8899
         host = args.host or "127.0.0.1"
@@ -147,12 +152,17 @@ def _run_proxy(args: argparse.Namespace) -> None:
     except ImportError:
         pass
 
+    debug_msg = ""
+    if debug:
+        debug_msg = f"  Debug:      ON ⚠️  (warning: exposes private data in logs)\n"
+
     print(
         f"\n"
         f"  SafeClaw Gateway\n"
         f"  {'─' * 35}\n"
         f"  LLM Proxy:  http://localhost:{port}/v1\n"
         f"  Target:     {target}\n"
+        f"{debug_msg}"
         f"{dashboard_msg}"
         f"{mcp_msg}"
         f"\n"
@@ -190,6 +200,7 @@ def _run_wrap(args: argparse.Namespace) -> None:
             detectors=detectors,
             policy=cfg.policy,  # type: ignore[attr-defined]
             dashboard=dashboard,
+            debug=False,  # debug mode not supported for wrap
         )
     else:
         port = args.port or _find_free_port()
@@ -203,6 +214,7 @@ def _run_wrap(args: argparse.Namespace) -> None:
             detectors=detectors,
             policy=policy,
             dashboard=dashboard,
+            debug=False,  # debug mode not supported for wrap
         )
 
     # Start proxy in a background thread
@@ -712,6 +724,11 @@ def main() -> None:
         type=float,
         default=None,
         help="Per-session budget cap in USD (returns 429 when exceeded)",
+    )
+    proxy_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug mode - log all requests to console",
     )
 
     # --- keygen subcommand ---

--- a/src/aceteam_aep/proxy/cli.py
+++ b/src/aceteam_aep/proxy/cli.py
@@ -105,9 +105,10 @@ def _run_proxy(args: argparse.Namespace) -> None:
 
     # Use unified config if --config provided, otherwise legacy args
     config_path = getattr(args, "config", None) or os.environ.get("AEP_CONFIG")
-    debug = getattr(args, "debug", False) or (config_path and getattr(_resolve_config(args), "debug", False))
+    debug = getattr(args, "debug", False)
     if config_path:
         cfg = _resolve_config(args)
+        debug = debug or getattr(cfg, "debug", False)
         detectors = _build_detectors(args, cfg.policy)  # type: ignore[attr-defined]
         app = create_proxy_app(
             target_base_url=cfg.target,  # type: ignore[attr-defined]

--- a/src/aceteam_aep/proxy/logutil.py
+++ b/src/aceteam_aep/proxy/logutil.py
@@ -1,0 +1,28 @@
+"""Logging helpers for the proxy CLI."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+_MARK = "_aep_proxy_debug_stderr"
+
+
+def configure_proxy_debug_logging() -> None:
+    """Wire stderr so DEBUG from ``aceteam_aep.proxy`` is visible.
+
+    Uvicorn only configures ``uvicorn.*`` loggers; library loggers often have no
+    handlers, and the stdlib ``lastResort`` handler only prints WARNING+.
+
+    Attaches one handler on the ``aceteam_aep.proxy`` package logger (does not
+    toggle ``propagate`` on children).
+    """
+    proxy_pkg = logging.getLogger("aceteam_aep.proxy")
+    if any(getattr(h, _MARK, False) for h in proxy_pkg.handlers):
+        return
+    proxy_pkg.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(sys.stderr)
+    setattr(handler, _MARK, True)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    proxy_pkg.addHandler(handler)

--- a/src/aceteam_aep/proxy/streaming.py
+++ b/src/aceteam_aep/proxy/streaming.py
@@ -79,6 +79,7 @@ async def handle_streaming_request(
     registry: DetectorRegistry,
     policy: EnforcementPolicy,
     on_complete: Any = None,
+    debug: bool = False,
 ) -> StreamingResponse:
     """Handle a streaming request through the proxy.
 
@@ -91,10 +92,14 @@ async def handle_streaming_request(
         registry: Safety detector registry
         policy: Enforcement policy
         on_complete: Callback(model, input_tokens, output_tokens, output_text, signals, decision)
+        debug: Enable debug logging for the stream
     """
 
     async def stream_generator() -> Any:
         accumulated_chunks: list[dict[str, Any]] = []
+
+        if debug:
+            log.debug("STREAM REQUEST %s: %s", call_id, target_url)
 
         async with httpx.AsyncClient(timeout=120.0) as client, client.stream(
             "POST",
@@ -109,6 +114,10 @@ async def handle_streaming_request(
                 if parsed:
                     accumulated_chunks.append(parsed)
 
+                # Debug: log each chunk (truncated)
+                if debug:
+                    log.debug("STREAM CHUNK %s: %s", call_id, line[:200] if line else "<empty>")
+
                 # Pass through to client immediately
                 yield f"{line}\n"
 
@@ -116,6 +125,16 @@ async def handle_streaming_request(
         model, output_text, input_tokens, output_tokens = _accumulate_stream_chunks(
             accumulated_chunks
         )
+
+        if debug:
+            log.debug(
+                "STREAM COMPLETE %s: model=%s, input_tokens=%d, output_tokens=%d, output_text=%s",
+                call_id,
+                model,
+                input_tokens,
+                output_tokens,
+                output_text[:500] if output_text else "",
+            )
 
         # Run safety detectors
         signals = registry.run_all(


### PR DESCRIPTION
When it is passed, we start the proxy with

```
justin@aceteamvm:~/aceteam-aep$ uv run aceteam-aep proxy --debug
INFO aceteam_aep.proxy.app: MCP gateway mounted at /mcp/

  SafeClaw Gateway
  ───────────────────────────────────
  LLM Proxy:  http://localhost:8899/v1
  Target:     https://api.openai.com
  Debug:      ON ⚠️  (warning: exposes private data in logs)
  Dashboard:  http://localhost:8899/aep/
  MCP:        http://localhost:8899/mcp/

  Point your agent here:
    export OPENAI_BASE_URL=http://localhost:8899/v1


INFO:     Started server process [2847338]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8899 (Press CTRL+C to quit)
```

Then debug logs look like this:

```
DEBUG aceteam_aep.proxy.app: REQUEST f073da27 POST /v1/chat/completions: headers={'host': 'localhost:8899', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'accept': 'application/json', 'content-type': 'application/json', 'user-agent': 'OpenAI/Python 1.109.1', 'x-stainless-lang': 'python', 'x-stainless-package-version': '1.109.1', 'x-stainless-os': 'Linux', 'x-stainless-arch': 'x64', 'x-stainless-runtime': 'CPython', 'x-stainless-runtime-version': '3.12.3', 'authorization': 'Bearer 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', 'x-stainless-async': 'false', 'x-stainless-retry-count': '0', 'x-stainless-read-timeout': '600', 'content-length': '95'}, body={'messages': [{'role': 'user', 'content': 'What is the capital of France?'}], 'model': 'gpt-4o-mini'}
```