### PR TITLE
Always track OpenAI costs

### DIFF
--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -20,7 +20,7 @@ import httpx
 from pydantic import ValidationError
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, RedirectResponse, Response
 from starlette.routing import Mount, Route
 
 from ..costs import CostTracker
@@ -114,6 +114,20 @@ def _extract_usage(data: dict[str, Any]) -> tuple[str, int, int]:
     input_tokens = usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0) or 0
     output_tokens = usage.get("completion_tokens", 0) or usage.get("output_tokens", 0) or 0
     return model, input_tokens, output_tokens
+
+
+def _ensure_openai_stream_usage(body: dict[str, Any], path: str) -> None:
+    """Ask OpenAI-compatible chat completion streams to include token usage in SSE.
+
+    Without ``stream_options.include_usage``, OpenAI omits ``usage`` from all stream
+    chunks, so the proxy records zero tokens and the dashboard shows no spend.
+    """
+    if not body.get("stream") or "/chat/completions" not in path:
+        return
+    opts = body.get("stream_options")
+    if not isinstance(opts, dict):
+        body["stream_options"] = {}
+    body["stream_options"]["include_usage"] = True
 
 
 class ProxyState:
@@ -461,6 +475,9 @@ def create_proxy_app(
 
         # --- STREAMING BRANCH ---
         if body.get("stream"):
+            _ensure_openai_stream_usage(body, path)
+            body_bytes = json.dumps(body).encode()
+
             from .streaming import handle_streaming_request
 
             # Start span BEFORE the stream begins to measure actual latency
@@ -489,6 +506,7 @@ def create_proxy_app(
                     model=model,
                     usage=usage,
                 )
+                state._call_costs.append(cost_node.compute_cost)
                 state.span_tracker.end_span(stream_span.span_id)
                 state.call_count += 1
                 state.signals.extend(signals)
@@ -707,8 +725,15 @@ def create_proxy_app(
         dashboard_app = create_dashboard(get_state=_get_state)
         # Look up endpoints by path to avoid fragile positional indices
         dash_endpoints = {r.path: r.endpoint for r in dashboard_app.routes}  # type: ignore[union-attr]
+
+        async def _redirect_aep_trailing_slash(_request: Request) -> RedirectResponse:
+            # Relative URLs like `api/state` resolve to /aep/api/state only when the
+            # page URL ends with /aep/; otherwise the browser resolves `api/state` to /api/state.
+            return RedirectResponse(url="/aep/", status_code=307)
+
         routes.extend(
             [
+                Route("/aep", _redirect_aep_trailing_slash, methods=["GET"]),
                 Route("/aep/", dash_endpoints["/"]),
                 Route("/aep/ciso", dash_endpoints["/ciso"]),
                 Route("/aep/api/state", dash_endpoints["/api/state"]),

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -205,6 +205,13 @@ class TestProxyDashboard:
         assert resp.status_code == 200
         assert "AEP Dashboard" in resp.text
 
+    def test_dashboard_redirects_aep_without_trailing_slash(self) -> None:
+        app = create_proxy_app(detectors=[CostAnomalyDetector()], dashboard=True)
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get("/aep")
+        assert resp.status_code == 307
+        assert resp.headers.get("location") == "/aep/"
+
     def test_dashboard_api_at_aep_path(self) -> None:
         app = create_proxy_app(detectors=[CostAnomalyDetector()], dashboard=True)
         client = TestClient(app)

--- a/tests/test_proxy_streaming.py
+++ b/tests/test_proxy_streaming.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from aceteam_aep.proxy.app import _ensure_openai_stream_usage
 from aceteam_aep.proxy.streaming import _accumulate_stream_chunks, _parse_sse_line
 
 
@@ -58,3 +59,21 @@ def test_accumulate_no_usage() -> None:
     assert text == "Hi"
     assert inp == 0  # no usage chunk
     assert out == 0
+
+
+def test_ensure_openai_stream_usage_sets_include_usage() -> None:
+    body: dict = {"model": "gpt-4o", "messages": [], "stream": True}
+    _ensure_openai_stream_usage(body, "/v1/chat/completions")
+    assert body["stream_options"]["include_usage"] is True
+
+
+def test_ensure_openai_stream_usage_skips_non_chat_path() -> None:
+    body: dict = {"stream": True}
+    _ensure_openai_stream_usage(body, "/v1/embeddings")
+    assert "stream_options" not in body
+
+
+def test_ensure_openai_stream_usage_skips_non_stream() -> None:
+    body: dict = {"stream": False}
+    _ensure_openai_stream_usage(body, "/v1/chat/completions")
+    assert "stream_options" not in body


### PR DESCRIPTION
## Summary
The dashboard often stayed at $0 for traffic that went through streaming chat completions, and could fail to load state when the UI was opened at /aep without a trailing slash.

## Root cause
Streaming & usage — For OpenAI-style Chat Completions, the API does not include token usage in SSE chunks unless the request sets stream_options.include_usage: true. Many clients omit this, so the proxy accumulated 0 input/output tokens, recorded $0 spend, and the dashboard reflected that.

Relative API URLs — The dashboard uses relative fetches like api/state. If the page is loaded as http://…/aep (no /), browsers resolve api/state to /api/state instead of /aep/api/state, so the poll can fail silently and the UI never updates.

## Changes
_ensure_openai_stream_usage — For POST bodies with stream: true on paths containing chat/completions, set stream_options.include_usage to true and re-serialize the forwarded body so upstream streams include usage for cost accounting.
Streaming path — Append streaming call costs to _call_costs (aligned with non-streaming) so savings / averages stay consistent.
Redirect — GET /aep → 307 → /aep/ so the dashboard base URL matches what relative api/* paths expect.
