### PR TITLE
Rename dashboard to /dashboard and add in-browser policy tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The gateway runs a single process on one port with three interfaces:
 | Path | What it does |
 |------|-------------|
 | `/v1/*` | OpenAI-compatible reverse proxy with safety enforcement |
-| `/aep/` | Dashboard — cost, signals, policy controls, setup wizard |
+| `/dashboard/` | Dashboard — cost, signals, policy controls, setup wizard |
 | `/mcp/` | MCP tools for Claude Code and any MCP client |
 
 ## Installation
@@ -35,7 +35,7 @@ The gateway prints three URLs on startup:
   SafeClaw Gateway
   ───────────────────────────────────
   LLM Proxy:  http://localhost:8899/v1
-  Dashboard:  http://localhost:8899/aep/
+  Dashboard:  http://localhost:8899/dashboard/
   MCP:        http://localhost:8899/mcp/
 ```
 
@@ -49,7 +49,7 @@ export OPENAI_API_KEY=sk-your-key
 openclaw run "analyze these financial statements"
 ```
 
-Open **http://localhost:8899/aep/** — every LLM call appears in real-time with cost, safety signals, and enforcement decisions.
+Open **http://localhost:8899/dashboard/** — every LLM call appears in real-time with cost, safety signals, and enforcement decisions.
 
 The proxy intercepts **both directions**:
 - **Incoming requests** — blocks dangerous prompts before they reach the API
@@ -104,7 +104,7 @@ Think **WireGuard + Tailscale**. WireGuard is a minimal wire protocol. Tailscale
 **Layer 1 — AEP Proxy (free, zero code changes)**
 - Sees all LLM traffic (input, output, tool calls, cost)
 - Runs safety detectors, enforces PASS/FLAG/BLOCK
-- Dashboard at `/aep/`
+- Dashboard at `/dashboard/`
 - Works with any language, any framework
 
 **Layer 2 — AEP SDK (application-level context)**

--- a/docs/business-model.md
+++ b/docs/business-model.md
@@ -166,7 +166,7 @@ export OPENAI_BASE_URL=http://localhost:8080/v1
 openclaw run "analyze these financial statements"
 
 # Terminal 3: Watch the dashboard
-open http://localhost:8080/aep/
+open http://localhost:8080/dashboard/
 ```
 
 **What attendees see:**

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -7,7 +7,7 @@ The AEP Gateway (SafeClaw) is a unified process serving three endpoints on a sin
 | Path | Protocol | Purpose |
 |------|----------|---------|
 | `/v1/*` | OpenAI-compatible HTTP | LLM reverse proxy with safety enforcement |
-| `/aep/*` | HTTP + HTML | Dashboard, safety API, policy controls |
+| `/dashboard/*` | HTTP + HTML | Dashboard, safety API, policy controls |
 | `/mcp/*` | MCP Streamable HTTP | Tool access for Claude Code and MCP clients |
 
 All three surfaces share one `ProxyState` — cost tracking, safety signals, decisions, and policy are live across every interface simultaneously.
@@ -21,7 +21,7 @@ All three surfaces share one `ProxyState` — cost tracking, safety signals, dec
 - Enforces PASS/FLAG/BLOCK decisions
 - Tracks cost per call via `CostTracker`
 - Optionally signs verdicts (Ed25519 + Merkle chain via `attestation.py`)
-- Serves the dashboard at `/aep/` and state API at `/aep/api/*`
+- Serves the dashboard at `/dashboard/` and state API at `/dashboard/api/*`
 
 ### Dashboard (`dashboard/templates/index.html`)
 
@@ -144,27 +144,27 @@ Dimensions are toggleable per policy YAML. The external judge service (AdaExtrac
 
 ## Runtime Safety Toggle
 
-`POST /aep/api/safety` enables/disables safety at runtime without restart:
+`POST /dashboard/api/safety` enables/disables safety at runtime without restart:
 
 ```bash
 # Safety off
-curl -X POST localhost:8899/aep/api/safety -d '{"enabled": false}'
+curl -X POST localhost:8899/dashboard/api/safety -d '{"enabled": false}'
 
 # Hot-swap policy
-curl -X POST localhost:8899/aep/api/safety -d '{"policy": {"default_action": "block"}}'
+curl -X POST localhost:8899/dashboard/api/safety -d '{"policy": {"default_action": "block"}}'
 
 # Check state
-curl localhost:8899/aep/api/safety
+curl localhost:8899/dashboard/api/safety
 ```
 
 The dashboard has a master toggle switch in the header. Per-detector and per-category checkboxes allow fine-grained control without restart.
 
 ## Signal Feedback Loop
 
-Operators mark flagged signals as confirmed (true positive) or dismissed (false positive) via the dashboard review buttons or `POST /aep/api/feedback`:
+Operators mark flagged signals as confirmed (true positive) or dismissed (false positive) via the dashboard review buttons or `POST /dashboard/api/feedback`:
 
 ```
-POST /aep/api/feedback → JSONL store → analyze FP rate → recommend threshold → apply to YAML
+POST /dashboard/api/feedback → JSONL store → analyze FP rate → recommend threshold → apply to YAML
 ```
 
 The system uses the 90th percentile of dismissed scores (capped below the lowest confirmed score) to suggest thresholds. Requires 5+ verdicts per detector.
@@ -207,7 +207,7 @@ Pre-built image: `ghcr.io/aceteam-ai/aep-proxy:latest`
 - Python 3.12 slim base
 - Safety models pre-downloaded (~235MB)
 - Binds to `0.0.0.0:8899`
-- Healthcheck on `/aep/`
+- Healthcheck on `/dashboard/`
 - Entrypoint: `aceteam-aep proxy`
 
 Published on tag push via GitHub Actions.

--- a/docs/superpowers/specs/2026-04-02-mcp-gateway-onramp-design.md
+++ b/docs/superpowers/specs/2026-04-02-mcp-gateway-onramp-design.md
@@ -22,7 +22,7 @@ Claude Code / OpenClaw / SafeClaw / Any Agent
     │      one process, one port      │
     │                                 │
     │  /v1/*     → LLM proxy          │  ← safety detectors, cost tracking
-    │  /aep/*    → dashboard + API    │  ← toggle, signals, policy, setup
+    │  /dashboard/*    → dashboard + API    │  ← toggle, signals, policy, setup
     │  /mcp/*    → MCP endpoint       │  ← tiered tools (local → connected → platform)
     │                                 │
     │  ┌─────────┐  ┌──────────────┐  │
@@ -39,9 +39,9 @@ Claude Code / OpenClaw / SafeClaw / Any Agent
 | Path | What | Available |
 |------|------|-----------|
 | `/v1/chat/completions` | LLM proxy (OpenAI-compatible) | Always |
-| `/aep/` | Dashboard (developer + executive + setup wizard) | Always |
-| `/aep/api/state` | Proxy state (cost, signals, spans) | Always |
-| `/aep/api/safety` | Safety toggle + policy swap | Always |
+| `/dashboard/` | Dashboard (developer + executive + setup wizard) | Always |
+| `/dashboard/api/state` | Proxy state (cost, signals, spans) | Always |
+| `/dashboard/api/safety` | Safety toggle + policy swap | Always |
 | `/mcp/` | MCP endpoint (streamable-http) | Always |
 
 ## Getting Started
@@ -82,7 +82,7 @@ $ podman run -p 8899:8899 ghcr.io/aceteam-ai/aep-proxy
 
   SafeClaw Gateway
   ─────────────────────────────────────
-  Dashboard:    http://localhost:8899/aep/
+  Dashboard:    http://localhost:8899/dashboard/
   LLM Proxy:    http://localhost:8899/v1
   MCP Endpoint: http://localhost:8899/mcp/
 
@@ -278,7 +278,7 @@ def create_proxy_app(state: ProxyState, ...):
 ### New vs Existing Tools
 
 Of the 4 Tier 1 tools, 2 exist in `mcp.py` (`check_safety`, `get_safety_status`) and 2 are net-new:
-- `set_safety_policy` — backs onto existing `POST /aep/api/safety` handler logic
+- `set_safety_policy` — backs onto existing `POST /dashboard/api/safety` handler logic
 - `get_cost_summary` — reads from `ProxyState.cost_tracker` and `_call_costs`
 
 ### Auth Model

--- a/docs/workshop-guide.md
+++ b/docs/workshop-guide.md
@@ -42,14 +42,14 @@ You'll see:
   ─────────────────────────────────
   Listening:  http://localhost:8080
   Target:     https://api.openai.com
-  Dashboard:  http://localhost:8080/aep/
+  Dashboard:  http://localhost:8080/dashboard/
 
   Usage:
     export OPENAI_BASE_URL=http://localhost:8080/v1
     openclaw run "your task here"
 ```
 
-Open **http://localhost:8080/aep/** in your browser. You'll see an empty dashboard — it'll light up as soon as calls flow through.
+Open **http://localhost:8080/dashboard/** in your browser. You'll see an empty dashboard — it'll light up as soon as calls flow through.
 
 ---
 
@@ -315,7 +315,7 @@ Your Agent (OpenClaw, LangChain, Python, curl)
 │  → Run output safety checks              │
 │  → BLOCK if PII/toxic (before agent)     │
 │  → Track cost + spans                    │
-│  → Serve dashboard at /aep/              │
+│  → Serve dashboard at /dashboard/              │
 └─────────────────┬───────────────────────┘
                   │
                   ▼
@@ -353,4 +353,4 @@ First run downloads ~300MB of HuggingFace models. They're cached after that. Use
 OpenClaw hardcodes its API base URL. You need to edit the model config — see Option C above.
 
 **Dashboard not updating:**
-The dashboard polls `/aep/api/state` every 2 seconds. If calls aren't appearing, verify your agent is actually pointing at `localhost:8080`.
+The dashboard polls `/dashboard/api/state` every 2 seconds. If calls aren't appearing, verify your agent is actually pointing at `localhost:8080`.

--- a/examples/headers_integration.sh
+++ b/examples/headers_integration.sh
@@ -59,4 +59,4 @@ curl -s "$PROXY/v1/chat/completions" \
 echo ""
 
 echo "=== Dashboard ==="
-echo "Open http://localhost:8080/aep/ to see all calls in real-time"
+echo "Open http://localhost:8080/dashboard/ to see all calls in real-time"

--- a/src/aceteam_aep/dashboard/templates/index.html
+++ b/src/aceteam_aep/dashboard/templates/index.html
@@ -1288,7 +1288,7 @@
       margin-bottom: 8px;
     }
 
-    /* ── Policy Tester (quick PAW evaluation in-browser) ── */
+    /* ── Policy Tester (evaluate a custom policy against text in-browser) ── */
     .tester-row {
       display: flex;
       gap: 10px;
@@ -1473,10 +1473,9 @@
     <div class="section" id="policy-tester-section" style="animation-delay: 0.24s;">
       <h2>Policy Tester</h2>
       <p style="color:var(--text-muted);font-size:12px;margin:0 0 10px;">
-        Evaluate a natural-language policy against arbitrary text — like
-        <a href="https://programasweights.com/browser" target="_blank" rel="noopener"
-          style="color:var(--accent-cyan);">programasweights.com/browser</a>, but against
-        the rules you've defined above. No agent needed.
+        Evaluate a natural-language policy against arbitrary text, without
+        running an agent. Pick one of the rules defined above, paste in a
+        sample, and see whether it passes or gets flagged.
       </p>
       <div class="tester-row">
         <select class="tester-select" id="tester-policy"></select>

--- a/src/aceteam_aep/dashboard/templates/index.html
+++ b/src/aceteam_aep/dashboard/templates/index.html
@@ -781,7 +781,7 @@
       letter-spacing: 0.8px;
     }
 
-    /* ── Policies (natural-language rules; API: /aep/api/custom-policies) ── */
+    /* ── Policies (natural-language rules; API: /dashboard/api/custom-policies) ── */
     .policies-list {
       display: flex;
       flex-direction: column;
@@ -1287,6 +1287,94 @@
       font-size: 12px;
       margin-bottom: 8px;
     }
+
+    /* ── Policy Tester (quick PAW evaluation in-browser) ── */
+    .tester-row {
+      display: flex;
+      gap: 10px;
+      align-items: stretch;
+      flex-wrap: wrap;
+      margin-bottom: 10px;
+    }
+
+    .tester-select,
+    .tester-input {
+      background: var(--bg-inset);
+      border: 1px solid var(--border);
+      color: var(--text-primary);
+      padding: 9px 12px;
+      border-radius: var(--radius);
+      font-family: var(--font-data);
+      font-size: 13px;
+    }
+
+    .tester-select {
+      min-width: 200px;
+    }
+
+    .tester-input {
+      flex: 1;
+      min-width: 220px;
+      resize: vertical;
+      min-height: 60px;
+    }
+
+    .tester-btn {
+      background: var(--accent-cyan);
+      color: var(--bg-deep);
+      border: none;
+      padding: 0 22px;
+      border-radius: 20px;
+      font-family: var(--font-label);
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+      letter-spacing: 0.3px;
+      transition: opacity 0.15s;
+    }
+
+    .tester-btn:hover { opacity: 0.9; }
+    .tester-btn:disabled { opacity: 0.4; cursor: wait; }
+
+    .tester-result {
+      padding: 10px 14px;
+      border-radius: var(--radius);
+      font-family: var(--font-data);
+      font-size: 13px;
+      border: 1px solid var(--border-subtle);
+      background: var(--bg-inset);
+      color: var(--text-muted);
+    }
+
+    .tester-result.passed {
+      border-color: rgba(46, 213, 115, 0.45);
+      color: var(--accent-green);
+    }
+
+    .tester-result.violated {
+      border-color: rgba(255, 71, 87, 0.45);
+      color: var(--accent-red);
+    }
+
+    /* ── Header settings (open setup wizard after first run) ── */
+    .settings-btn {
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      padding: 4px 12px;
+      border-radius: 14px;
+      font-family: var(--font-label);
+      font-size: 11px;
+      letter-spacing: 0.4px;
+      cursor: pointer;
+      margin-left: 10px;
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    .settings-btn:hover {
+      border-color: var(--accent-cyan);
+      color: var(--accent-cyan);
+    }
   </style>
 </head>
 
@@ -1341,6 +1429,9 @@
       <button id="btn-dev" class="active" onclick="setView('dev')">Developer</button>
       <button id="btn-ciso" onclick="setView('ciso')">Executive</button>
     </div>
+    <button class="settings-btn" id="settings-btn" onclick="openSetup()" title="API key &amp; agent setup">
+      <span id="settings-btn-label">SETUP</span>
+    </button>
   </h1>
 
   <!-- ===== DEVELOPER VIEW ===== -->
@@ -1377,6 +1468,23 @@
     <div class="section" id="policies-section" style="animation-delay: 0.22s;">
       <h2>Policies</h2>
       <div id="policies-container"></div>
+    </div>
+
+    <div class="section" id="policy-tester-section" style="animation-delay: 0.24s;">
+      <h2>Policy Tester</h2>
+      <p style="color:var(--text-muted);font-size:12px;margin:0 0 10px;">
+        Evaluate a natural-language policy against arbitrary text — like
+        <a href="https://programasweights.com/browser" target="_blank" rel="noopener"
+          style="color:var(--accent-cyan);">programasweights.com/browser</a>, but against
+        the rules you've defined above. No agent needed.
+      </p>
+      <div class="tester-row">
+        <select class="tester-select" id="tester-policy"></select>
+        <textarea class="tester-input" id="tester-text"
+          placeholder="Enter text to evaluate against the selected policy…"></textarea>
+        <button class="tester-btn" id="tester-run" onclick="runPolicyTest()">Test</button>
+      </div>
+      <div class="tester-result" id="tester-result">Pick a policy and enter text, then press Test.</div>
     </div>
 
     <div class="section">
@@ -1503,16 +1611,36 @@
     var collapsedGroups = {};
     var safetyEnabled = true;
 
-    // Setup wizard — show on first visit
+    // Setup wizard — the proxy tells us whether a BYOK key is already stored.
+    // (Previously we relied on localStorage, which left users stranded behind a
+    // cookie/localStorage clear whenever they wanted to update a key.)
+    function refreshKeyHint(info) {
+      var label = document.getElementById('settings-btn-label');
+      if (!label) return;
+      label.textContent = info && info.set ? 'KEY: ' + info.hint : 'SETUP';
+    }
+
     function checkFirstRun() {
-      if (localStorage.getItem('safeclaw-setup-done')) return;
-      fetch('api/state').then(function (r) { return r.json(); }).then(function (state) {
-        if (state.calls > 0) {
-          localStorage.setItem('safeclaw-setup-done', '1');
-          return;
+      fetch('api/api-key').then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      }).then(function (info) {
+        refreshKeyHint(info);
+        if (!info.set) {
+          document.getElementById('setup-overlay').style.display = 'flex';
         }
-        document.getElementById('setup-overlay').style.display = 'flex';
       }).catch(function () { });
+    }
+
+    function openSetup() {
+      document.getElementById('setup-step-1').classList.add('active');
+      document.getElementById('setup-step-2').classList.remove('active');
+      document.getElementById('setup-byok').style.display = 'none';
+      document.getElementById('setup-aceteam').style.display = 'none';
+      document.getElementById('setup-api-key').value = '';
+      var options = document.querySelectorAll('.setup-option');
+      for (var i = 0; i < options.length; i++) { options[i].classList.remove('selected'); }
+      document.getElementById('setup-overlay').style.display = 'flex';
     }
 
     function selectSetupOption(option, evt) {
@@ -1524,11 +1652,28 @@
     }
 
     function saveApiKey() {
-      var key = document.getElementById('setup-api-key').value.trim();
+      var input = document.getElementById('setup-api-key');
+      var btn = input.parentElement.querySelector('.setup-btn');
+      var key = input.value.trim();
       if (!key) return;
-      localStorage.setItem('safeclaw-api-key-hint', key.substring(0, 8) + '...');
-      document.getElementById('setup-step-1').classList.remove('active');
-      document.getElementById('setup-step-2').classList.add('active');
+      if (btn) { btn.disabled = true; btn.textContent = 'Saving…'; }
+      fetch('api/api-key', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ api_key: key })
+      }).then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      }).then(function (info) {
+        refreshKeyHint(info);
+        input.value = '';
+        document.getElementById('setup-step-1').classList.remove('active');
+        document.getElementById('setup-step-2').classList.add('active');
+      }).catch(function () {
+        alert('Failed to save API key. Is the proxy running?');
+      }).then(function () {
+        if (btn) { btn.disabled = false; btn.textContent = 'Save & Continue'; }
+      });
     }
 
     function copySetupText(elementId) {
@@ -1541,7 +1686,6 @@
     }
 
     function closeSetup() {
-      localStorage.setItem('safeclaw-setup-done', '1');
       document.getElementById('setup-overlay').style.display = 'none';
     }
 
@@ -2119,7 +2263,7 @@
       }
       details.innerHTML = html;
     }
-    // ── Policies (proxy API: /aep/api/custom-policies)
+    // ── Policies (proxy API: /dashboard/api/custom-policies)
     var policies = [];
     var editingPolicyId = null; // null = not editing, 'new' = adding, string = editing existing
 
@@ -2157,6 +2301,7 @@
         .then(function (data) {
           policies = data.policies || [];
           renderPolicies();
+          renderTesterPolicies();
         })
         .catch(function () {
           policies = [];
@@ -2167,7 +2312,69 @@
           err.className = 'policy-empty';
           err.textContent = 'Policies could not be loaded from the server.';
           container.appendChild(err);
+          renderTesterPolicies();
         });
+    }
+
+    function renderTesterPolicies() {
+      var sel = document.getElementById('tester-policy');
+      if (!sel) return;
+      var prev = sel.value;
+      sel.textContent = '';
+      if (policies.length === 0) {
+        var opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = 'No policies defined — add one above';
+        sel.appendChild(opt);
+        sel.disabled = true;
+        return;
+      }
+      sel.disabled = false;
+      policies.forEach(function (p) {
+        var o = document.createElement('option');
+        o.value = p.id;
+        o.textContent = p.name + (p.enabled ? '' : ' (disabled)');
+        sel.appendChild(o);
+      });
+      if (prev) sel.value = prev;
+    }
+
+    function runPolicyTest() {
+      var sel = document.getElementById('tester-policy');
+      var text = document.getElementById('tester-text').value;
+      var resultEl = document.getElementById('tester-result');
+      var btn = document.getElementById('tester-run');
+      if (!sel || !sel.value) {
+        resultEl.className = 'tester-result';
+        resultEl.textContent = 'Select a policy first.';
+        return;
+      }
+      resultEl.className = 'tester-result';
+      resultEl.textContent = 'Evaluating…';
+      btn.disabled = true;
+      fetch('api/policy-test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ policy_id: sel.value, text: text })
+      }).then(function (r) {
+        return r.json().then(function (body) { return { ok: r.ok, body: body }; });
+      }).then(function (res) {
+        if (!res.ok) {
+          resultEl.className = 'tester-result';
+          resultEl.textContent = (res.body && res.body.error) || 'Evaluation failed';
+          return;
+        }
+        var passes = !!res.body.passes;
+        resultEl.className = 'tester-result ' + (passes ? 'passed' : 'violated');
+        resultEl.textContent = passes
+          ? 'PASSED — text complies with "' + res.body.policy_name + '"'
+          : 'VIOLATED — text breaks "' + res.body.policy_name + '" (' + res.body.severity + ' severity)';
+      }).catch(function () {
+        resultEl.className = 'tester-result';
+        resultEl.textContent = 'Request failed. Is the proxy running?';
+      }).then(function () {
+        btn.disabled = false;
+      });
     }
 
     function renderPolicies() {

--- a/src/aceteam_aep/mcp_gateway.py
+++ b/src/aceteam_aep/mcp_gateway.py
@@ -108,7 +108,7 @@ def create_mcp_app(state: ProxyState) -> ASGIApp | None:
                     "block_on": sorted(state.policy.block_on),
                     "flag_on": sorted(state.policy.flag_on),
                 },
-                "dashboard_url": "http://localhost:8899/aep/",
+                "dashboard_url": "http://localhost:8899/dashboard/",
             },
             indent=2,
         )

--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -160,6 +160,10 @@ class ProxyState:
         self._started_at = datetime.now(UTC)
         self.blocked_count = 0
         self.safety_enabled = True
+        # Runtime BYOK API key, set via POST /dashboard/api/api-key and used as
+        # the Authorization header when forwarding /v1/* requests that don't
+        # already carry one (e.g. the in-dashboard playground).
+        self.api_key: str | None = None
         self.budget = Decimal(str(budget)) if budget is not None else None
         self.budget_per_session = (
             Decimal(str(budget_per_session)) if budget_per_session is not None else None
@@ -476,6 +480,15 @@ def create_proxy_app(
         for key in ("x-api-key", "anthropic-version"):
             if request.headers.get(key):
                 forward_headers[key] = request.headers[key]
+        # Fall back to runtime BYOK key when caller didn't set auth headers
+        # (e.g. the in-dashboard playground fetches /v1/chat/completions
+        # from the browser without exposing the raw key to JS).
+        if state.api_key and "Authorization" not in forward_headers:
+            if "anthropic" in state.target_base_url or path == "/v1/messages":
+                forward_headers.setdefault("x-api-key", state.api_key)
+                forward_headers.setdefault("anthropic-version", "2023-06-01")
+            else:
+                forward_headers["Authorization"] = f"Bearer {state.api_key}"
         # Strip X-AEP-* headers so they don't leak to the LLM provider
         forward_headers = strip_aep_headers(forward_headers)
 
@@ -732,17 +745,18 @@ def create_proxy_app(
         # Look up endpoints by path to avoid fragile positional indices
         dash_endpoints = {r.path: r.endpoint for r in dashboard_app.routes}  # type: ignore[union-attr]
 
-        async def _redirect_aep_trailing_slash(_request: Request) -> RedirectResponse:
-            # Relative URLs like `api/state` resolve to /aep/api/state only when the
-            # page URL ends with /aep/; otherwise the browser resolves `api/state` to /api/state.
-            return RedirectResponse(url="/aep/", status_code=307)
+        async def _redirect_dashboard_trailing_slash(_request: Request) -> RedirectResponse:
+            # Relative URLs like `api/state` resolve to /dashboard/api/state only when
+            # the page URL ends with /dashboard/; otherwise the browser resolves
+            # `api/state` to /api/state.
+            return RedirectResponse(url="/dashboard/", status_code=307)
 
         routes.extend(
             [
-                Route("/aep", _redirect_aep_trailing_slash, methods=["GET"]),
-                Route("/aep/", dash_endpoints["/"]),
-                Route("/aep/ciso", dash_endpoints["/ciso"]),
-                Route("/aep/api/state", dash_endpoints["/api/state"]),
+                Route("/dashboard", _redirect_dashboard_trailing_slash, methods=["GET"]),
+                Route("/dashboard/", dash_endpoints["/"]),
+                Route("/dashboard/ciso", dash_endpoints["/ciso"]),
+                Route("/dashboard/api/state", dash_endpoints["/api/state"]),
             ]
         )
 
@@ -752,7 +766,7 @@ def create_proxy_app(
 
     _feedback_store = FeedbackStore("aep-feedback.jsonl")
 
-    # Feedback API — POST /aep/api/feedback
+    # Feedback API — POST /dashboard/api/feedback
     async def feedback_handler(request: Request) -> Response:
         """Record a signal verdict (confirmed/dismissed) from an operator."""
         try:
@@ -779,7 +793,7 @@ def create_proxy_app(
             media_type="application/json",
         )
 
-    # Feedback summary API — GET /aep/api/feedback/summary
+    # Feedback summary API — GET /dashboard/api/feedback/summary
     async def feedback_summary_handler(request: Request) -> Response:
         """Return feedback analysis and threshold recommendations."""
         from ..feedback import recommend_thresholds
@@ -814,7 +828,7 @@ def create_proxy_app(
             media_type="application/json",
         )
 
-    # Safety toggle API — GET/POST /aep/api/safety
+    # Safety toggle API — GET/POST /dashboard/api/safety
     async def safety_toggle_handler(request: Request) -> Response:
         """Toggle safety on/off or swap the enforcement policy at runtime.
 
@@ -961,20 +975,103 @@ def create_proxy_app(
         state.custom_policy_store.upsert(updated)
         return Response(json.dumps(updated.model_dump()), media_type="application/json")
 
+    # BYOK API key management — GET returns a hint, POST sets the key, DELETE clears.
+    # The raw key is only held in process memory (never written to disk) and is used
+    # as the fallback Authorization header when a /v1/* request arrives without one.
+    async def api_key_handler(request: Request) -> Response:
+        def _hint(key: str | None) -> dict[str, Any]:
+            if not key:
+                return {"set": False, "hint": None}
+            visible = key[:7] if len(key) > 7 else key[:3]
+            return {"set": True, "hint": f"{visible}..."}
+
+        if request.method == "GET":
+            return JSONResponse(_hint(state.api_key))
+
+        if request.method == "DELETE":
+            state.api_key = None
+            return JSONResponse(_hint(None))
+
+        body, json_err = await _read_json_body(request)
+        if json_err is not None:
+            return json_err
+        if not isinstance(body, dict):
+            return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
+        key = body.get("api_key")
+        if not isinstance(key, str) or not key.strip():
+            return JSONResponse(
+                {"error": "api_key must be a non-empty string"}, status_code=400
+            )
+        state.api_key = key.strip()
+        log.info("BYOK API key updated (len=%d)", len(state.api_key))
+        return JSONResponse(_hint(state.api_key))
+
+    # Policy tester — evaluate a single custom policy against arbitrary text,
+    # so users can sanity-check a rule from the dashboard without wiring up an
+    # agent. Mirrors programasweights.com/browser but against policies that
+    # already live in this process.
+    async def policy_test_handler(request: Request) -> Response:
+        body, json_err = await _read_json_body(request)
+        if json_err is not None:
+            return json_err
+        if not isinstance(body, dict):
+            return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
+        raw_id = body.get("policy_id")
+        text = body.get("text", "")
+        if not isinstance(raw_id, str) or not isinstance(text, str):
+            return JSONResponse(
+                {"error": "policy_id (string) and text (string) required"}, status_code=400
+            )
+        policy_id = _normalize_policy_id(raw_id)
+        if policy_id is None:
+            return JSONResponse({"error": "invalid policy id"}, status_code=400)
+        policy = state.custom_policy_store.get(policy_id)
+        if policy is None:
+            return JSONResponse({"error": "custom policy not found"}, status_code=404)
+        try:
+            passes = await policy(text)
+        except Exception as exc:
+            log.warning("Policy test failed for %s: %s", policy.name, exc)
+            return JSONResponse(
+                {"error": "policy evaluation failed", "detail": str(exc)},
+                status_code=500,
+            )
+        return JSONResponse(
+            {
+                "policy_id": policy.id,
+                "policy_name": policy.name,
+                "passes": passes,
+                "severity": policy.severity,
+                "applies_to": policy.applies_to,
+            }
+        )
+
     routes.extend(
         [
-            Route("/aep/api/feedback", feedback_handler, methods=["POST"]),
-            Route("/aep/api/feedback/summary", feedback_summary_handler, methods=["GET"]),
-            Route("/aep/api/safety", safety_toggle_handler, methods=["POST", "GET"]),
+            Route("/dashboard/api/feedback", feedback_handler, methods=["POST"]),
             Route(
-                "/aep/api/custom-policies/{policy_id}",
+                "/dashboard/api/feedback/summary", feedback_summary_handler, methods=["GET"]
+            ),
+            Route("/dashboard/api/safety", safety_toggle_handler, methods=["POST", "GET"]),
+            Route(
+                "/dashboard/api/custom-policies/{policy_id}",
                 custom_policy_item_handler,
                 methods=["GET", "PUT", "DELETE"],
             ),
             Route(
-                "/aep/api/custom-policies",
+                "/dashboard/api/custom-policies",
                 custom_policies_collection_handler,
                 methods=["GET", "POST"],
+            ),
+            Route(
+                "/dashboard/api/api-key",
+                api_key_handler,
+                methods=["GET", "POST", "DELETE"],
+            ),
+            Route(
+                "/dashboard/api/policy-test",
+                policy_test_handler,
+                methods=["POST"],
             ),
         ]
     )

--- a/src/aceteam_aep/proxy/cli.py
+++ b/src/aceteam_aep/proxy/cli.py
@@ -155,7 +155,7 @@ def _run_proxy(args: argparse.Namespace) -> None:
 
     dashboard_msg = ""
     if dashboard:
-        dashboard_msg = f"  Dashboard:  http://localhost:{port}/aep/\n"
+        dashboard_msg = f"  Dashboard:  http://localhost:{port}/dashboard/\n"
 
     mcp_msg = ""
     try:
@@ -278,7 +278,7 @@ def _run_wrap(args: argparse.Namespace) -> None:
     try:
         import httpx
 
-        resp = httpx.get(f"http://localhost:{port}/aep/api/state", timeout=2.0)
+        resp = httpx.get(f"http://localhost:{port}/dashboard/api/state", timeout=2.0)
         if resp.status_code == 200:
             state = resp.json()
             _print_wrap_summary(state)
@@ -374,7 +374,7 @@ def _run_connect(args: argparse.Namespace) -> None:
     try:
         import httpx
 
-        r = httpx.get(f"http://localhost:{proxy_port}/aep/api/state", timeout=2)
+        r = httpx.get(f"http://localhost:{proxy_port}/dashboard/api/state", timeout=2)
         if r.status_code == 200:
             print(f"  ✓ Proxy detected on port {proxy_port}")
             print("  ℹ Restart the proxy to activate AceTeam features")
@@ -651,7 +651,7 @@ def _run_setup(args: argparse.Namespace) -> None:
         print(f"    export OPENAI_BASE_URL=http://localhost:{port}/v1")
 
     # Step 5: Open dashboard
-    dashboard_url = f"http://localhost:{port}/aep/"
+    dashboard_url = f"http://localhost:{port}/dashboard/"
     print(f"\n  {'─' * 35}")
     print(f"  Dashboard:  {dashboard_url}")
     print(f"  LLM Proxy:  http://localhost:{port}/v1")

--- a/src/aceteam_aep/top.py
+++ b/src/aceteam_aep/top.py
@@ -1,6 +1,6 @@
 """aep top — terminal dashboard for the AEP safety proxy.
 
-Like htop, but for AI agent safety. Polls /aep/api/state and renders
+Like htop, but for AI agent safety. Polls /dashboard/api/state and renders
 a live terminal UI showing calls, cost, signals, and enforcement.
 
 Usage:
@@ -21,7 +21,7 @@ import httpx
 
 def _fetch_state(base_url: str) -> dict | None:
     try:
-        resp = httpx.get(f"{base_url}/aep/api/state", timeout=3.0)
+        resp = httpx.get(f"{base_url}/dashboard/api/state", timeout=3.0)
         if resp.status_code == 200:
             return resp.json()
     except Exception:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,7 +50,7 @@ def aep_proxy():
     base_url = f"http://localhost:{port}"
     for _ in range(30):
         try:
-            r = httpx.get(f"{base_url}/aep/api/state", timeout=1)
+            r = httpx.get(f"{base_url}/dashboard/api/state", timeout=1)
             if r.status_code == 200:
                 break
         except httpx.ConnectError:
@@ -67,5 +67,5 @@ def aep_proxy():
 
 def get_proxy_state(base_url: str) -> dict:
     """Fetch current proxy state."""
-    r = httpx.get(f"{base_url}/aep/api/state", timeout=5)
+    r = httpx.get(f"{base_url}/dashboard/api/state", timeout=5)
     return r.json()

--- a/tests/integration/test_dashboard_attestation.py
+++ b/tests/integration/test_dashboard_attestation.py
@@ -54,7 +54,7 @@ def test_dashboard_attestation_data(tmp_path):
         base_url = f"http://localhost:{port}"
         for _ in range(30):
             try:
-                r = httpx.get(f"{base_url}/aep/api/state", timeout=1)
+                r = httpx.get(f"{base_url}/dashboard/api/state", timeout=1)
                 if r.status_code == 200:
                     break
             except httpx.ConnectError:
@@ -70,7 +70,7 @@ def test_dashboard_attestation_data(tmp_path):
         }
 
         # 3. Check state before any calls — attestation should be enabled but empty
-        state = httpx.get(f"{base_url}/aep/api/state", timeout=5).json()
+        state = httpx.get(f"{base_url}/dashboard/api/state", timeout=5).json()
         assert state["attestation"]["enabled"] is True
         assert state["attestation"]["signer_id"] == "proxy:dashboard-test"
         assert state["attestation"]["chain_height"] == 0
@@ -89,7 +89,7 @@ def test_dashboard_attestation_data(tmp_path):
         assert r.status_code == 200
 
         # 5. Check state after call — chain should have 1 entry
-        state = httpx.get(f"{base_url}/aep/api/state", timeout=5).json()
+        state = httpx.get(f"{base_url}/dashboard/api/state", timeout=5).json()
         assert state["attestation"]["chain_height"] == 1
         assert state["attestation"]["latest_hash"] is not None
         assert state["attestation"]["latest_hash"].startswith("sha256:")
@@ -113,11 +113,11 @@ def test_dashboard_attestation_data(tmp_path):
         assert r2.status_code == 200
         assert r2.headers["x-aep-chain-height"] == "1"
 
-        state = httpx.get(f"{base_url}/aep/api/state", timeout=5).json()
+        state = httpx.get(f"{base_url}/dashboard/api/state", timeout=5).json()
         assert state["attestation"]["chain_height"] == 2
 
         # 8. Dashboard HTML loads
-        dash = httpx.get(f"{base_url}/aep/", timeout=5)
+        dash = httpx.get(f"{base_url}/dashboard/", timeout=5)
         assert dash.status_code == 200
         assert "attestation-section" in dash.text
         assert "Attestation (Signed Verdicts)" in dash.text
@@ -143,7 +143,7 @@ def test_dashboard_no_attestation_without_signing(tmp_path):
         base_url = f"http://localhost:{port}"
         for _ in range(30):
             try:
-                r = httpx.get(f"{base_url}/aep/api/state", timeout=1)
+                r = httpx.get(f"{base_url}/dashboard/api/state", timeout=1)
                 if r.status_code == 200:
                     break
             except httpx.ConnectError:
@@ -152,7 +152,7 @@ def test_dashboard_no_attestation_without_signing(tmp_path):
             proc.kill()
             raise RuntimeError("Proxy failed to start")
 
-        state = httpx.get(f"{base_url}/aep/api/state", timeout=5).json()
+        state = httpx.get(f"{base_url}/dashboard/api/state", timeout=5).json()
         assert state["attestation"] is None
 
     finally:

--- a/tests/integration/test_safety_toggle.py
+++ b/tests/integration/test_safety_toggle.py
@@ -36,7 +36,7 @@ def _start_proxy(port: int, extra_args: list[str] | None = None):
     base_url = f"http://localhost:{port}"
     for _ in range(30):
         try:
-            r = httpx.get(f"{base_url}/aep/api/state", timeout=1)
+            r = httpx.get(f"{base_url}/dashboard/api/state", timeout=1)
             if r.status_code == 200:
                 return proc, base_url
         except httpx.ConnectError:
@@ -71,7 +71,7 @@ def _call(base_url: str, prompt: str) -> httpx.Response:
 
 def _toggle_safety(base_url: str, enabled: bool) -> dict:
     r = httpx.post(
-        f"{base_url}/aep/api/safety",
+        f"{base_url}/dashboard/api/safety",
         json={"enabled": enabled},
         timeout=5,
     )
@@ -80,7 +80,7 @@ def _toggle_safety(base_url: str, enabled: bool) -> dict:
 
 
 def _get_safety_state(base_url: str) -> dict:
-    r = httpx.get(f"{base_url}/aep/api/safety", timeout=5)
+    r = httpx.get(f"{base_url}/dashboard/api/safety", timeout=5)
     assert r.status_code == 200
     return r.json()
 
@@ -130,7 +130,7 @@ def test_safety_toggle_on_off_on():
 
 
 def test_policy_hot_swap():
-    """Hot-swap policy at runtime via /aep/api/safety."""
+    """Hot-swap policy at runtime via /dashboard/api/safety."""
     if not os.environ.get("OPENAI_API_KEY"):
         __import__("pytest").skip("OPENAI_API_KEY not set")
 
@@ -144,7 +144,7 @@ def test_policy_hot_swap():
 
         # Swap to passthrough policy (all pass, nothing blocked)
         r = httpx.post(
-            f"{base_url}/aep/api/safety",
+            f"{base_url}/dashboard/api/safety",
             json={
                 "policy": {
                     "default_action": "pass",
@@ -165,7 +165,7 @@ def test_policy_hot_swap():
 
         # Swap back to strict policy
         r = httpx.post(
-            f"{base_url}/aep/api/safety",
+            f"{base_url}/dashboard/api/safety",
             json={
                 "policy": {
                     "default_action": "flag",
@@ -203,7 +203,7 @@ def test_disable_detector_via_policy():
         assert r.status_code == 400
 
         r = httpx.post(
-            f"{proxy}/aep/api/safety",
+            f"{proxy}/dashboard/api/safety",
             json={
                 "policy": {
                     "default_action": "flag",
@@ -241,7 +241,7 @@ def test_confidence_headers_on_blocked():
         assert r.status_code == 400
 
         # Check proxy state for signals with scores
-        state = httpx.get(f"{base_url}/aep/api/state", timeout=5).json()
+        state = httpx.get(f"{base_url}/dashboard/api/state", timeout=5).json()
         signals = state.get("signals", [])
         assert len(signals) > 0, "Expected safety signals on blocked call"
 

--- a/tests/integration/test_signed_proxy.py
+++ b/tests/integration/test_signed_proxy.py
@@ -60,7 +60,7 @@ def test_signed_proxy_end_to_end(tmp_path):
         base_url = f"http://localhost:{port}"
         for _ in range(30):
             try:
-                r = httpx.get(f"{base_url}/aep/api/state", timeout=1)
+                r = httpx.get(f"{base_url}/dashboard/api/state", timeout=1)
                 if r.status_code == 200:
                     break
             except httpx.ConnectError:

--- a/tests/test_custom_policies_api.py
+++ b/tests/test_custom_policies_api.py
@@ -25,13 +25,13 @@ class TestCustomPoliciesAPI:
         app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
 
-        listed = client.get("/aep/api/custom-policies").json()
+        listed = client.get("/dashboard/api/custom-policies").json()
         names = {p["name"] for p in listed["policies"]}
         assert names == {"English only", "US SSN pattern (input)"}
         assert all(p["enabled"] is False for p in listed["policies"])
 
         create = client.post(
-            "/aep/api/custom-policies",
+            "/dashboard/api/custom-policies",
             json={"name": "Block foo", "rule": "no foo", "enabled": True},
         )
         assert create.status_code == 201
@@ -43,23 +43,23 @@ class TestCustomPoliciesAPI:
         assert body["applies_to"] == "both"
         assert body["severity"] == "high"
 
-        listed = client.get("/aep/api/custom-policies").json()
+        listed = client.get("/dashboard/api/custom-policies").json()
         assert len(listed["policies"]) == 4
         assert any(p["id"] == policy_id for p in listed["policies"])
 
-        one = client.get(f"/aep/api/custom-policies/{policy_id}")
+        one = client.get(f"/dashboard/api/custom-policies/{policy_id}")
         assert one.status_code == 200
         assert one.json() == body
 
         put = client.put(
-            f"/aep/api/custom-policies/{policy_id}",
+            f"/dashboard/api/custom-policies/{policy_id}",
             json={"name": "Block foo", "rule": "no foo", "enabled": False},
         )
         assert put.status_code == 200
         assert put.json()["enabled"] is False
 
         put2 = client.put(
-            f"/aep/api/custom-policies/{policy_id}",
+            f"/dashboard/api/custom-policies/{policy_id}",
             json={"name": "Renamed", "rule": "updated rule", "enabled": True},
         )
         assert put2.status_code == 200
@@ -67,33 +67,33 @@ class TestCustomPoliciesAPI:
         assert put2.json()["rule"] == "updated rule"
         assert put2.json()["enabled"] is True
 
-        deleted = client.delete(f"/aep/api/custom-policies/{policy_id}")
+        deleted = client.delete(f"/dashboard/api/custom-policies/{policy_id}")
         assert deleted.status_code == 204
 
-        assert client.get(f"/aep/api/custom-policies/{policy_id}").status_code == 404
+        assert client.get(f"/dashboard/api/custom-policies/{policy_id}").status_code == 404
 
     def test_put_requires_all_fields(self) -> None:
         app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
         r = client.post(
-            "/aep/api/custom-policies",
+            "/dashboard/api/custom-policies",
             json={"name": "x", "rule": "y", "enabled": True},
         )
         pid = r.json()["id"]
-        bad = client.put(f"/aep/api/custom-policies/{pid}", json={"enabled": False})
+        bad = client.put(f"/dashboard/api/custom-policies/{pid}", json={"enabled": False})
         assert bad.status_code == 400
 
     def test_invalid_uuid(self) -> None:
         app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
-        assert client.get("/aep/api/custom-policies/not-a-uuid").status_code == 400
+        assert client.get("/dashboard/api/custom-policies/not-a-uuid").status_code == 400
 
     def test_create_rejects_client_id(self) -> None:
         """POST ignores any client-supplied id; server issues UUID via CustomPolicy."""
         app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
         r = client.post(
-            "/aep/api/custom-policies",
+            "/dashboard/api/custom-policies",
             json={
                 "id": "00000000-0000-0000-0000-000000000001",
                 "name": "x",
@@ -108,7 +108,7 @@ class TestCustomPoliciesAPI:
         app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
         r = client.post(
-            "/aep/api/custom-policies",
+            "/dashboard/api/custom-policies",
             json={
                 "name": "Out only",
                 "rule": "no secrets",
@@ -127,7 +127,7 @@ class TestCustomPoliciesAPI:
         app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
         r = client.post(
-            "/aep/api/custom-policies",
+            "/dashboard/api/custom-policies",
             json={
                 "name": "Scoped",
                 "rule": "r",
@@ -138,13 +138,90 @@ class TestCustomPoliciesAPI:
         )
         pid = r.json()["id"]
         put = client.put(
-            f"/aep/api/custom-policies/{pid}",
+            f"/dashboard/api/custom-policies/{pid}",
             json={"name": "Renamed", "rule": "new", "enabled": False},
         )
         assert put.status_code == 200
         b = put.json()
         assert b["applies_to"] == "input"
         assert b["severity"] == "medium"
+
+    def test_api_key_endpoint_roundtrip(self) -> None:
+        """POST stores the BYOK key in memory; GET returns a hint, DELETE clears it."""
+        app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
+        client = TestClient(app)
+
+        assert client.get("/dashboard/api/api-key").json() == {"set": False, "hint": None}
+
+        saved = client.post(
+            "/dashboard/api/api-key", json={"api_key": "sk-abc123def456"}
+        ).json()
+        assert saved["set"] is True
+        assert saved["hint"].startswith("sk-abc1")
+
+        hint = client.get("/dashboard/api/api-key").json()
+        assert hint["set"] is True
+        assert hint["hint"] == saved["hint"]
+
+        cleared = client.delete("/dashboard/api/api-key").json()
+        assert cleared == {"set": False, "hint": None}
+
+    def test_api_key_rejects_empty_and_non_string(self) -> None:
+        app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
+        client = TestClient(app)
+        assert client.post("/dashboard/api/api-key", json={"api_key": ""}).status_code == 400
+        assert (
+            client.post("/dashboard/api/api-key", json={"api_key": 42}).status_code == 400
+        )
+        assert client.post("/dashboard/api/api-key", json={}).status_code == 400
+
+    def test_policy_test_endpoint_returns_violation(self) -> None:
+        """Stub the CustomPolicy's __call__ so we don't need the PAW compiler online."""
+        from aceteam_aep.safety.custom import CustomPolicy
+
+        app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
+        client = TestClient(app)
+        created = client.post(
+            "/dashboard/api/custom-policies",
+            json={"name": "Block foo", "rule": "must not contain foo", "enabled": True},
+        ).json()
+        policy_id = created["id"]
+
+        async def fake_call(self, text):  # noqa: ANN001
+            return "foo" not in text
+
+        with patch.object(CustomPolicy, "__call__", fake_call):
+            passing = client.post(
+                "/dashboard/api/policy-test",
+                json={"policy_id": policy_id, "text": "hello world"},
+            ).json()
+            assert passing["passes"] is True
+            assert passing["policy_name"] == "Block foo"
+
+            failing = client.post(
+                "/dashboard/api/policy-test",
+                json={"policy_id": policy_id, "text": "hello foo"},
+            ).json()
+            assert failing["passes"] is False
+
+    def test_policy_test_endpoint_validates_input(self) -> None:
+        app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
+        client = TestClient(app)
+        # Missing fields
+        assert client.post("/dashboard/api/policy-test", json={}).status_code == 400
+        # Bogus id
+        bad = client.post(
+            "/dashboard/api/policy-test", json={"policy_id": "nope", "text": "x"}
+        )
+        assert bad.status_code == 400
+        # Valid uuid but unknown policy
+        from uuid import uuid4
+
+        missing = client.post(
+            "/dashboard/api/policy-test",
+            json={"policy_id": str(uuid4()), "text": "x"},
+        )
+        assert missing.status_code == 404
 
     def test_rejects_multiple_custom_safety_detectors(self) -> None:
         store = CustomPolicyStore()

--- a/tests/test_dashboard_views.py
+++ b/tests/test_dashboard_views.py
@@ -1,7 +1,7 @@
 """Integration tests for dashboard developer + executive view data.
 
 Exercises the proxy with a mix of PASS/FLAG/BLOCK calls and governance
-headers, then verifies the /aep/api/state endpoint returns correct data
+headers, then verifies the /dashboard/api/state endpoint returns correct data
 for both views.
 """
 
@@ -140,7 +140,7 @@ def _make_call(
 
 
 class TestDeveloperView:
-    """Verify /aep/api/state returns correct data for the developer view."""
+    """Verify /dashboard/api/state returns correct data for the developer view."""
 
     def test_pass_flag_block_mix(self) -> None:
         """Make 3 calls (PASS, FLAG, BLOCK) and verify state reflects all."""
@@ -149,7 +149,7 @@ class TestDeveloperView:
         pass_client = TestClient(pass_app)
         _make_call(pass_client, content="normal request")
 
-        state = pass_client.get("/aep/api/state").json()
+        state = pass_client.get("/dashboard/api/state").json()
         assert state["calls"] == 1
         assert state["action"] == "pass"
         assert len(state["signals"]) == 0
@@ -159,7 +159,7 @@ class TestDeveloperView:
         flag_client = TestClient(flag_app)
         _make_call(flag_client, content="mildly unsafe")
 
-        state = flag_client.get("/aep/api/state").json()
+        state = flag_client.get("/dashboard/api/state").json()
         assert state["calls"] == 1
         assert state["action"] == "flag"
         assert len(state["signals"]) >= 1
@@ -171,7 +171,7 @@ class TestDeveloperView:
         resp = _make_call(block_client, content="run nmap scan")
         assert resp.status_code == 400
 
-        state = block_client.get("/aep/api/state").json()
+        state = block_client.get("/dashboard/api/state").json()
         assert state["calls"] == 1
         assert state["action"] == "block"
 
@@ -181,7 +181,7 @@ class TestDeveloperView:
         client = TestClient(app)
         _make_call(client)
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert len(state["spans"]) == 1
         span = state["spans"][0]
         assert "cost" in span
@@ -194,7 +194,7 @@ class TestDeveloperView:
         client = TestClient(app)
         _make_call(client)
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         span = state["spans"][0]
         call_id = span["call_id"]
         assert call_id is not None
@@ -209,7 +209,7 @@ class TestDeveloperView:
         client = TestClient(app)
         _make_call(client)
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         signal = state["signals"][0]
         assert "score" in signal
         assert signal["score"] == pytest.approx(0.78, abs=0.01)
@@ -234,7 +234,7 @@ class TestDeveloperView:
         client = TestClient(app)
         _make_call(client)
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["signals"][0]["score"] is None
 
     def test_signal_grouping_by_call_id(self) -> None:
@@ -244,7 +244,7 @@ class TestDeveloperView:
         _make_call(client, content="call one")
         _make_call(client, content="call two")
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 2
         call_ids = {s["call_id"] for s in state["signals"]}
         assert len(call_ids) == 2, "Each call should produce signals with a unique call_id"
@@ -255,7 +255,7 @@ class TestDeveloperView:
         client = TestClient(app)
         _make_call(client)
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert all("type" in s for s in state["signals"])
         assert state["signals"][0]["type"] == "content_safety"
 
@@ -266,13 +266,13 @@ class TestDeveloperView:
 
 
 class TestExecutiveView:
-    """Verify /aep/api/state returns correct data for the executive view."""
+    """Verify /dashboard/api/state returns correct data for the executive view."""
 
     def test_session_started_present(self) -> None:
         """State includes session_started timestamp."""
         app = create_proxy_app(detectors=[NoopDetector()], dashboard=True)
         client = TestClient(app)
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert "session_started" in state
         assert "T" in state["session_started"]  # ISO format
 
@@ -283,7 +283,7 @@ class TestExecutiveView:
         _make_call(client)
         _make_call(client)
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 2
         assert len(state["signals"]) == 0
         # Frontend computes: (calls - blocked) / calls * 100 = 100%
@@ -297,7 +297,7 @@ class TestExecutiveView:
         _make_call(client, content="nmap scan")
         _make_call(client, content="another nmap scan")
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 2
         high_signals = [s for s in state["signals"] if s["severity"] == "high"]
         assert len(high_signals) >= 2
@@ -336,7 +336,7 @@ class TestExecutiveView:
             },
         )
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 3
 
         # Governance contexts should have all 3 entries
@@ -376,7 +376,7 @@ class TestExecutiveView:
             },
         )
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         gov = state["governance"]
         assert len(gov) == 1
         assert gov[0]["classification"] == "restricted"
@@ -455,7 +455,7 @@ class TestExecutiveView:
         assert resp.status_code == 400
 
         # Verify full state
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 3
         assert state["cost"] >= 0
         assert "session_started" in state

--- a/tests/test_e2e_proxy.py
+++ b/tests/test_e2e_proxy.py
@@ -199,7 +199,7 @@ class TestOpenClawStyleE2E:
             ],
         )
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 3
         assert state["cost"] > 0
         assert len(state["spans"]) == 3
@@ -245,7 +245,7 @@ class TestOpenClawStyleE2E:
             ],
         )
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 2
         assert len(state["spans"]) == 2
 
@@ -273,7 +273,7 @@ class TestOpenClawStyleE2E:
         det.mode = "pass"
         _make_call(client, messages=[{"role": "user", "content": "Summarize"}])
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 4
         assert state["action"] == "pass"  # latest call was safe
 
@@ -318,7 +318,7 @@ class TestOpenClawStyleE2E:
             },
         )
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 3
 
         # Governance contexts
@@ -353,7 +353,7 @@ class TestOpenClawStyleE2E:
             response=_chat_response(model="gpt-4o-mini", input_tokens=20, output_tokens=40),
         )
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 2
         models = {s["executor"] for s in state["spans"]}
         assert "gpt-4o" in models
@@ -387,11 +387,11 @@ class TestOpenClawStyleE2E:
 
         assert resp.status_code == 500
         # Dashboard should still work
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert "cost" in state
 
     def test_full_session_state_contract(self) -> None:
-        """Verify the complete /aep/api/state schema for dashboard consumption."""
+        """Verify the complete /dashboard/api/state schema for dashboard consumption."""
         det = ScenarioDetector()
         app = create_proxy_app(detectors=[det], dashboard=True)
         client = TestClient(app)
@@ -402,7 +402,7 @@ class TestOpenClawStyleE2E:
             headers={"X-AEP-Entity": "org:demo"},
         )
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
 
         # Top-level fields
         assert isinstance(state["cost"], (int, float))
@@ -445,7 +445,7 @@ class TestOpenClawStyleE2E:
             det.mode = "flag" if i % 10 == 0 else "pass"
             _make_call(client, messages=[{"role": "user", "content": f"Call {i}"}])
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["calls"] == 50
         assert len(state["spans"]) == 50
         assert state["cost"] > 0

--- a/tests/test_feedback_api.py
+++ b/tests/test_feedback_api.py
@@ -29,7 +29,7 @@ class TestFeedbackAPI:
         client = TestClient(app)
 
         resp = client.post(
-            "/aep/api/feedback",
+            "/dashboard/api/feedback",
             json={
                 "signal_type": "pii",
                 "score": 0.72,
@@ -54,7 +54,7 @@ class TestFeedbackAPI:
         client = TestClient(app)
 
         resp = client.post(
-            "/aep/api/feedback",
+            "/dashboard/api/feedback",
             json={"signal_type": "pii", "verdict": "maybe"},
         )
         assert resp.status_code == 400
@@ -65,7 +65,7 @@ class TestFeedbackAPI:
             app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
 
-        resp = client.post("/aep/api/feedback", json={"signal_type": "pii"})
+        resp = client.post("/dashboard/api/feedback", json={"signal_type": "pii"})
         assert resp.status_code == 400
 
     def test_feedback_summary(self, tmp_path: Path) -> None:
@@ -79,16 +79,16 @@ class TestFeedbackAPI:
 
         for score in [0.3, 0.35, 0.4, 0.45, 0.5]:
             client.post(
-                "/aep/api/feedback",
+                "/dashboard/api/feedback",
                 json={"signal_type": "pii", "score": score, "verdict": "dismissed"},
             )
         for score in [0.8, 0.9]:
             client.post(
-                "/aep/api/feedback",
+                "/dashboard/api/feedback",
                 json={"signal_type": "pii", "score": score, "verdict": "confirmed"},
             )
 
-        resp = client.get("/aep/api/feedback/summary?min_verdicts=5")
+        resp = client.get("/dashboard/api/feedback/summary?min_verdicts=5")
         assert resp.status_code == 200
         data = resp.json()
         assert data["total_verdicts"] == 7

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -104,6 +104,29 @@ class TestProxyForwarding:
             call_kwargs = mock_client.request.call_args
             assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer sk-real-key"
 
+    def test_uses_dashboard_byok_key_when_header_missing(self) -> None:
+        """When a /v1/* request has no Authorization header, the proxy should
+        fall back to the BYOK key set via POST /dashboard/api/api-key."""
+        app = create_proxy_app(detectors=[CostAnomalyDetector()], dashboard=True)
+        client = TestClient(app)
+
+        client.post("/dashboard/api/api-key", json={"api_key": "sk-byok-from-dashboard"})
+
+        with patch("aceteam_aep.proxy.app.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.request = AsyncMock(return_value=_mock_upstream(_openai_response()))
+            mock_client_cls.return_value = mock_client
+
+            client.post("/v1/chat/completions", json=_openai_request())
+
+            call_kwargs = mock_client.request.call_args
+            assert (
+                call_kwargs.kwargs["headers"]["Authorization"]
+                == "Bearer sk-byok-from-dashboard"
+            )
+
 
 class TestProxySafetyBlocking:
     """Test that the proxy blocks unsafe content."""
@@ -198,24 +221,24 @@ class TestProxyState:
 class TestProxyDashboard:
     """Test that the dashboard is mounted on the proxy."""
 
-    def test_dashboard_at_aep_path(self) -> None:
+    def test_dashboard_at_dashboard_path(self) -> None:
         app = create_proxy_app(detectors=[CostAnomalyDetector()], dashboard=True)
         client = TestClient(app)
-        resp = client.get("/aep/")
+        resp = client.get("/dashboard/")
         assert resp.status_code == 200
         assert "AEP Dashboard" in resp.text
 
-    def test_dashboard_redirects_aep_without_trailing_slash(self) -> None:
+    def test_dashboard_redirects_without_trailing_slash(self) -> None:
         app = create_proxy_app(detectors=[CostAnomalyDetector()], dashboard=True)
         client = TestClient(app, follow_redirects=False)
-        resp = client.get("/aep")
+        resp = client.get("/dashboard")
         assert resp.status_code == 307
-        assert resp.headers.get("location") == "/aep/"
+        assert resp.headers.get("location") == "/dashboard/"
 
-    def test_dashboard_api_at_aep_path(self) -> None:
+    def test_dashboard_api_at_dashboard_path(self) -> None:
         app = create_proxy_app(detectors=[CostAnomalyDetector()], dashboard=True)
         client = TestClient(app)
-        resp = client.get("/aep/api/state")
+        resp = client.get("/dashboard/api/state")
         assert resp.status_code == 200
         data = resp.json()
         assert "cost" in data

--- a/tests/test_safety_toggle.py
+++ b/tests/test_safety_toggle.py
@@ -83,7 +83,7 @@ class TestSafetyToggle:
         client = TestClient(app)
 
         # Disable safety
-        toggle = client.post("/aep/api/safety", json={"enabled": False})
+        toggle = client.post("/dashboard/api/safety", json={"enabled": False})
         assert toggle.status_code == 200
         assert toggle.json()["safety_enabled"] is False
 
@@ -95,11 +95,11 @@ class TestSafetyToggle:
         app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
         client = TestClient(app)
 
-        state = client.get("/aep/api/state").json()
+        state = client.get("/dashboard/api/state").json()
         assert state["safety_enabled"] is True
 
-        client.post("/aep/api/safety", json={"enabled": False})
-        state = client.get("/aep/api/state").json()
+        client.post("/dashboard/api/safety", json={"enabled": False})
+        state = client.get("/dashboard/api/state").json()
         assert state["safety_enabled"] is False
 
     def test_reenable_safety_blocks_again(self) -> None:
@@ -107,12 +107,12 @@ class TestSafetyToggle:
         client = TestClient(app)
 
         # Off → passes
-        client.post("/aep/api/safety", json={"enabled": False})
+        client.post("/dashboard/api/safety", json={"enabled": False})
         resp = _make_call(client)
         assert resp.status_code == 200
 
         # On again → blocks
-        client.post("/aep/api/safety", json={"enabled": True})
+        client.post("/dashboard/api/safety", json={"enabled": True})
         resp = _make_call(client)
         assert resp.status_code == 400
 
@@ -121,12 +121,12 @@ class TestSafetyToggle:
         client = TestClient(app)
 
         # Default policy
-        state = client.post("/aep/api/safety", json={}).json()
+        state = client.post("/dashboard/api/safety", json={}).json()
         assert state["policy"]["default_action"] == "flag"
 
         # Swap to block policy
         resp = client.post(
-            "/aep/api/safety",
+            "/dashboard/api/safety",
             json={"policy": {"default_action": "block", "block_on": ["high", "medium"]}},
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- Moves the dashboard and its API from `/aep/*` to `/dashboard/*` everywhere — proxy routes, CLI status output, `aceteam-aep top`, MCP gateway metadata, HTML template comments, docs, and tests. Old `/aep/*` paths are gone (no backwards-compat shim).
- Fixes the BYOK setup flow that previously did nothing. `saveApiKey()` now POSTs the key to a new in-memory endpoint `POST/GET/DELETE /dashboard/api/api-key`, and the proxy uses that key as the `Authorization` fallback when a `/v1/*` call arrives without one. A new **SETUP** button in the header reopens the wizard so users can rotate/clear keys without clearing cookies.
- Adds a **Policy Tester** section (like `programasweights.com/browser` but for the rules already defined on the dashboard). Backed by `POST /dashboard/api/policy-test`, which evaluates a single `CustomPolicy` against arbitrary text and returns pass/fail + severity.

## Test plan

- [x] `uv run pytest tests` (non-integration) — 424 passed, 15 skipped, 1 pre-existing failure (`test_crud_flow` asserts old policy names) deselected.
- [x] New tests: `test_api_key_endpoint_roundtrip`, `test_api_key_rejects_empty_and_non_string`, `test_policy_test_endpoint_returns_violation`, `test_policy_test_endpoint_validates_input`, `test_uses_dashboard_byok_key_when_header_missing`.
- [x] `uv run ruff check` clean on changed files.
- [x] Manual smoke: `/dashboard/`, `/dashboard` → 307, `/aep/` → 404, api-key GET/POST/DELETE work, policy-test validates input.
- [ ] Manual browser test: verify the SETUP button reopens the wizard, Policy Tester renders dropdown + result styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)