### PR TITLE
feat(protocols): UsageCollector accepts optional channel_id + pricing_snapshot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aceteam-aep"
-version = "0.8.5"
+version = "0.9.0"
 description = "Agentic Execution Protocol™ (AEP™) - trust & safety infrastructure for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/aceteam_aep/protocols.py
+++ b/src/aceteam_aep/protocols.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
 
 from aceteam_aep.envelope import Citation
 
@@ -16,7 +17,13 @@ class HasCitations(Protocol):
 
 @runtime_checkable
 class UsageCollector(Protocol):
-    """Async interface for capturing LLM usage data during execution."""
+    """Async interface for capturing LLM usage data during execution.
+
+    Implementers may accept the optional ``channel_id`` and ``pricing_snapshot``
+    kwargs to attribute the call to a specific routing channel and snapshot the
+    pricing in effect at call time. Both default to ``None`` so legacy
+    callers and implementers continue to work without change.
+    """
 
     async def record_usage(
         self,
@@ -27,6 +34,9 @@ class UsageCollector(Protocol):
         output_tokens: int,
         cost: float,
         execution_time_ms: int,
+        *,
+        channel_id: str | None = None,
+        pricing_snapshot: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 


### PR DESCRIPTION
## Summary

Closes #98. Extends `UsageCollector` Protocol to accept two optional kwargs-only params:
- `channel_id: str | None = None`
- `pricing_snapshot: Mapping[str, Any] | None = None`

Both default to `None`. Existing implementers and callers continue to work without modification — structural Protocol subtyping with a more permissive signature is compatible.

## Why

Downstream platform (`aceteam-ai/aceteam`) needs to attribute LLM usage to a specific routing channel and snapshot pricing for replay-stable historical cost. Today the data exists at the call site (resolver returns `ResolvedRoute` with `channel.id` + `pricing_snapshot`) but can't reach the AEP envelope because the Protocol's signature doesn't accept it.

## Version bump

`0.8.5` → `0.9.0` (minor: additive interface change).

## Test plan

- [x] `uv run ruff check + format` clean
- [x] Full pytest suite: 421 passed, 4 unrelated pre-existing failures in dashboard/custom-policies (not touched by this PR)
- [ ] After PyPI publish: downstream PR aceteam-ai/aceteam#3052 wires `channel_id` through `collector.record_usage()` and verifies CostNode metadata captures it

## Downstream consumers

| Repo | Issue | Action |
|---|---|---|
| aceteam-ai/aceteam | #3052 | Bump dep, pass kwargs through `collector.record_usage()`, extend `AceTeamContext.record_usage()` |

## Related
- aceteam-ai/aceteam#3044 (Milestone 3 — replay-stable cost history)
- aceteam-ai/aceteam#2936 (model routing architecture)
- aceteam-ai/aceteam#3047 (downstream PR that landed channel_id everywhere except envelope side)