### PR TITLE
fix(proxy): strip trailing /v1 from target_base_url

### DIFF
--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -1112,6 +1112,12 @@ def create_proxy_app(
                     {"error": "base_url must start with http:// or https://"},
                     status_code=400,
                 )
+            # Proxy forwards by concatenating target_base_url with the incoming
+            # request path, which already starts with /v1/... A trailing /v1 on
+            # the target produces /v1/v1/chat/completions and 404s. Strip it so
+            # OpenAI-SDK conventions (base_url ending in /v1) work transparently.
+            if candidate.endswith("/v1"):
+                candidate = candidate[: -len("/v1")]
             state.target_base_url = candidate
             log.info("Upstream base URL updated to %s", candidate)
         log.info("BYOK API key updated (len=%d)", len(state.api_key))

--- a/tests/test_custom_policies_api.py
+++ b/tests/test_custom_policies_api.py
@@ -344,6 +344,41 @@ class TestCustomPoliciesAPI:
         )
         assert client.post("/dashboard/api/api-key", json={}).status_code == 400
 
+    def test_api_key_strips_trailing_v1_from_base_url(self) -> None:
+        """OpenAI-SDK convention is base_url ending in /v1; the proxy concatenates
+        base_url with the request path (which already includes /v1/), so a
+        trailing /v1 on the target produces /v1/v1/chat/completions and 404s.
+        Strip it transparently so users can paste either form."""
+        import gc
+
+        from aceteam_aep.proxy.app import ProxyState
+
+        app = create_proxy_app(detectors=[_NoopDetector()], dashboard=True)
+        client = TestClient(app)
+
+        # Find the ProxyState owned by this app instance via the api_key we set.
+        def state_for_key(key: str) -> ProxyState:
+            return next(
+                s for s in gc.get_objects() if isinstance(s, ProxyState) and s.api_key == key
+            )
+
+        # Trailing /v1 — must be stripped.
+        client.post(
+            "/dashboard/api/api-key",
+            json={
+                "api_key": "sk-strip-test-1",
+                "base_url": "https://aceteam.ai/api/gateway/v1",
+            },
+        )
+        assert state_for_key("sk-strip-test-1").target_base_url == "https://aceteam.ai/api/gateway"
+
+        # No /v1 — left alone.
+        client.post(
+            "/dashboard/api/api-key",
+            json={"api_key": "sk-strip-test-2", "base_url": "https://api.openai.com"},
+        )
+        assert state_for_key("sk-strip-test-2").target_base_url == "https://api.openai.com"
+
     def test_policy_test_endpoint_returns_violation(self) -> None:
         """Stub the CustomPolicy's __call__ so we don't need the PAW compiler online."""
         from aceteam_aep.safety.custom import CustomPolicy


### PR DESCRIPTION
## Summary
- Proxy forwards by concatenating `target_base_url` with the incoming request path (which already starts with `/v1/...`). A trailing `/v1` on the target produces `/v1/v1/chat/completions` and 404s upstream.
- This silently broke chat for AceTeam connect users — the connect flow shipped `base_url=https://aceteam.ai/api/gateway/v1` (matching the consumer-facing `OPENAI_BASE_URL` convention), and OpenClaw saw the resulting upstream 404 as an "incomplete terminal response."
- Strip a trailing `/v1` defensively so both forms (with `/v1` and without) work transparently.

Companion fix in aceteam: aceteam-ai/aceteam#3148 drops the `/v1` at source.

## Test plan
- [x] New unit test: `test_api_key_strips_trailing_v1_from_base_url` covers the strip + the no-op cases
- [x] Manual: hot-patched onto a running proxy, AceTeam connect flow → chat round-trips through gpt-4o
- [ ] CI green