### PR TITLE
feat(dashboard): show org name (not UUID) in profile drawer

### DIFF
--- a/src/aceteam_aep/dashboard/templates/index.html
+++ b/src/aceteam_aep/dashboard/templates/index.html
@@ -1770,12 +1770,8 @@
         <span class="profile-row-value" id="profile-key-hint">—</span>
       </div>
       <div class="profile-row">
-        <span class="profile-row-label">User ID</span>
-        <span class="profile-row-value muted" id="profile-user-id">—</span>
-      </div>
-      <div class="profile-row">
-        <span class="profile-row-label">Organization ID</span>
-        <span class="profile-row-value muted" id="profile-org-id">—</span>
+        <span class="profile-row-label">Organization</span>
+        <span class="profile-row-value" id="profile-org">—</span>
       </div>
     </div>
     <div class="profile-actions">
@@ -2176,8 +2172,9 @@
         var providerName = rawLabel ? rawLabel.split('·').pop().trim() : (info.provider || 'Unknown');
         document.getElementById('profile-provider').textContent = providerName;
         document.getElementById('profile-key-hint').textContent = info.hint || '—';
-        document.getElementById('profile-user-id').textContent = account.user_id || '—';
-        document.getElementById('profile-org-id').textContent = account.organization_id || '—';
+        // Prefer the human-readable org name; fall back to the UUID only when
+        // we couldn't look up a name (older keys, BYOK, transient lookup miss).
+        document.getElementById('profile-org').textContent = account.organization_name || account.organization_id || '—';
         var drawer = document.getElementById('profile-drawer');
         drawer.classList.add('open');
         drawer.setAttribute('aria-hidden', 'false');
@@ -2307,16 +2304,16 @@
       var key = params.get('aceteam_key');
       var baseUrl = params.get('aceteam_base');
       var email = params.get('aceteam_email');
-      var userId = params.get('aceteam_user_id');
       var orgId = params.get('aceteam_org_id');
+      var orgName = params.get('aceteam_org_name');
       if (!key) return false;
       history.replaceState(null, '', window.location.pathname);
       var body = { api_key: key, base_url: baseUrl || undefined };
-      if (email || userId || orgId) {
+      if (email || orgId || orgName) {
         body.connected_account = {};
         if (email) body.connected_account.email = email;
-        if (userId) body.connected_account.user_id = userId;
         if (orgId) body.connected_account.organization_id = orgId;
+        if (orgName) body.connected_account.organization_name = orgName;
       }
       fetch('api/api-key', {
         method: 'POST',

--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -1023,11 +1023,11 @@ def create_proxy_app(
                 return
             state.connected_account = {
                 "email": email.strip(),
-                "user_id": data.get("user_id")
-                if isinstance(data.get("user_id"), str)
-                else None,
                 "organization_id": data.get("organization_id")
                 if isinstance(data.get("organization_id"), str)
+                else None,
+                "organization_name": data.get("organization_name")
+                if isinstance(data.get("organization_name"), str)
                 else None,
             }
         except Exception as err:  # noqa: BLE001 — best-effort fetch
@@ -1106,11 +1106,11 @@ def create_proxy_app(
             if isinstance(email, str) and email.strip():
                 state.connected_account = {
                     "email": email.strip(),
-                    "user_id": connected.get("user_id")
-                    if isinstance(connected.get("user_id"), str)
-                    else None,
                     "organization_id": connected.get("organization_id")
                     if isinstance(connected.get("organization_id"), str)
+                    else None,
+                    "organization_name": connected.get("organization_name")
+                    if isinstance(connected.get("organization_name"), str)
                     else None,
                 }
         base_url = body.get("base_url")

--- a/tests/test_custom_policies_api.py
+++ b/tests/test_custom_policies_api.py
@@ -207,14 +207,15 @@ class TestCustomPoliciesAPI:
                 "api_key": "act_xxxxxxxxxxxxxxxx",
                 "connected_account": {
                     "email": "jason@example.com",
-                    "user_id": "u_123",
+                    "organization_id": "org_123",
+                    "organization_name": "Acme Corp",
                 },
             },
         ).json()
         assert saved["connected_account"] == {
             "email": "jason@example.com",
-            "user_id": "u_123",
-            "organization_id": None,
+            "organization_id": "org_123",
+            "organization_name": "Acme Corp",
         }
         assert client.get("/dashboard/api/api-key").json()["connected_account"][
             "email"
@@ -240,6 +241,7 @@ class TestCustomPoliciesAPI:
                 "auth_type": "api_key",
                 "user_id": "u_42",
                 "organization_id": "org_42",
+                "organization_name": "Org Forty-Two",
                 "email": "introspected@example.com",
                 "key_id": "key_42",
                 "key_name": "Test key",
@@ -268,8 +270,8 @@ class TestCustomPoliciesAPI:
 
         assert saved["connected_account"] == {
             "email": "introspected@example.com",
-            "user_id": "u_42",
             "organization_id": "org_42",
+            "organization_name": "Org Forty-Two",
         }
         # Confirm the whoami URL was derived from base_url's host, not the
         # full gateway path.


### PR DESCRIPTION
## Summary
- Drop the `User ID` row from the profile drawer (UUID was noise).
- Replace `Organization ID` (UUID) with `Organization` (human-readable name), with a graceful UUID fallback when no name is available.
- Proxy now stores `connected_account.organization_name` in addition to the id; supplied either by the connect-flow URL fragment or by the upstream `/api/whoami` refresh.

## Test plan
- [x] `uv run pytest tests/test_custom_policies_api.py -k "api_key or routing"` (9 passed)
- [x] Hot-patched local container — drawer shows organization name post-reconnect.
- [ ] Pairs with aceteam-ai/aceteam#new (forwards `aceteam_org_name` in the connect-flow fragment); merging this side first is fine — the proxy falls back to the org UUID when no name is sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)