### PR TITLE
feat(proxy): auto-sync openclaw.json from gateway /v1/models on connect

### DIFF
--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -37,6 +37,8 @@ from ..spans import SpanTracker
 from ..types import Usage
 from .headers import build_response_headers, parse_aep_headers, strip_aep_headers
 from .logutil import configure_proxy_debug_logging
+from .openclaw_sync import get_configured_path as _openclaw_config_path
+from .openclaw_sync import refresh_openclaw_config
 from .redis_publisher import build_event, publish_event
 
 log = logging.getLogger(__name__)
@@ -176,6 +178,11 @@ class ProxyState:
         # /api/whoami introspect on existing keys). None for raw BYOK users
         # since we have no way to look them up.
         self.connected_account: dict[str, Any] | None = None
+        # Last status from the openclaw.json auto-sync (when AEP_OPENCLAW_CONFIG_PATH
+        # is configured). The dashboard polls this to surface a "catalog
+        # updated — restart gateway to apply" banner. None until the first
+        # sync attempt for this state.
+        self.openclaw_config_status: dict[str, Any] | None = None
         self.budget = Decimal(str(budget)) if budget is not None else None
         self.budget_per_session = (
             Decimal(str(budget_per_session)) if budget_per_session is not None else None
@@ -1134,6 +1141,18 @@ def create_proxy_app(
         # upstream gateway. Skip for non-act_* keys inside _refresh_*.
         if state.connected_account is None:
             await _refresh_connected_account()
+        # Auto-sync the OpenClaw catalog from the AceTeam gateway whenever a
+        # fresh act_* key lands. Opt-in via env: when AEP_OPENCLAW_CONFIG_PATH
+        # is set (i.e., compose mounts the openclaw config dir into the proxy),
+        # we mirror /v1/models into openclaw.json so users don't have to
+        # hand-edit it as new models get seeded into the AceTeam catalog.
+        config_path = _openclaw_config_path()
+        if config_path and state.api_key and state.api_key.startswith("act_"):
+            state.openclaw_config_status = await refresh_openclaw_config(
+                api_key=state.api_key,
+                target_base_url=state.target_base_url,
+                config_path=config_path,
+            )
         return JSONResponse(_hint(state.api_key))
 
     # Policy tester — evaluate a single custom policy against arbitrary text,
@@ -1173,6 +1192,22 @@ def create_proxy_app(
                 "passes": passes,
                 "severity": policy.severity,
                 "applies_to": policy.applies_to,
+            }
+        )
+
+    # OpenClaw config sync status — drives the dashboard banner that tells
+    # users when openclaw.json was auto-refreshed from the AceTeam catalog
+    # and whether they need to restart the gateway to apply it. Status is
+    # populated by api_key_handler after a successful act_* connect.
+    async def openclaw_config_status_handler(request: Request) -> Response:
+        if request.method != "GET":
+            return JSONResponse({"error": "GET only"}, status_code=405)
+        config_path = _openclaw_config_path()
+        return JSONResponse(
+            {
+                "enabled": config_path is not None,
+                "config_path": config_path,
+                "status": state.openclaw_config_status,
             }
         )
 
@@ -1318,6 +1353,11 @@ def create_proxy_app(
             Route(
                 "/dashboard/api/routing",
                 routing_handler,
+                methods=["GET"],
+            ),
+            Route(
+                "/dashboard/api/openclaw-config-status",
+                openclaw_config_status_handler,
                 methods=["GET"],
             ),
         ]

--- a/src/aceteam_aep/proxy/openclaw_sync.py
+++ b/src/aceteam_aep/proxy/openclaw_sync.py
@@ -1,0 +1,220 @@
+"""Auto-sync OpenClaw's openclaw.json from the AceTeam gateway's /v1/models.
+
+When the SafeClaw user connects via the dashboard, an `act_*` key lands in
+ProxyState. The Next.js gateway at ``${target_base_url}/v1/models`` knows
+which models that org can route through (BYOK keys + platform fallbacks),
+so the right design is to mirror that catalog into the OpenClaw config
+instead of asking users to hand-edit JSON.
+
+Trade-off: OpenClaw doesn't hot-reload openclaw.json. This module writes
+the file but doesn't restart the gateway — the new catalog appears on the
+next compose restart. Status is surfaced via ``ProxyState.openclaw_config_status``
+so the dashboard can show a "restart to apply" banner.
+
+Wiring: enabled by setting ``AEP_OPENCLAW_CONFIG_PATH=/path/to/openclaw.json``
+in the proxy's environment. The SafeClaw compose stack mounts the OpenClaw
+config dir into the proxy so this path resolves.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+
+def get_configured_path() -> str | None:
+    """Return the openclaw.json sync path from env, or None if unset."""
+    raw = os.environ.get("AEP_OPENCLAW_CONFIG_PATH", "").strip()
+    return raw or None
+
+
+def _resolve_models_url(target_base_url: str) -> str | None:
+    """Build the /v1/models URL from the proxy's target_base_url.
+
+    target_base_url for AceTeam looks like ``https://aceteam.ai/api/gateway``
+    (no /v1 suffix — proxy convention). The /v1/models endpoint is at
+    ``<host>/<basepath>/v1/models``. Returns None if target_base_url is
+    malformed (so we can no-op cleanly during startup).
+    """
+    parsed = urlparse(target_base_url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    base = target_base_url.rstrip("/")
+    return f"{base}/v1/models"
+
+
+def _transform_models_to_providers(models: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Group OpenAI /v1/models entries by ``owned_by`` → OpenClaw provider stanzas.
+
+    Each provider stanza routes through the local aep-proxy (``http://aep-proxy:8899/v1``)
+    with the sentinel ``aep-proxy-managed`` key — same convention as the
+    static seed in safeclaw-site/install.sh::write_openclaw_config.
+    """
+    providers: dict[str, dict[str, Any]] = {}
+    for m in models:
+        owner = (m.get("owned_by") or "unknown").lower()
+        provider = providers.setdefault(
+            owner,
+            {
+                "baseUrl": "http://aep-proxy:8899/v1",
+                "apiKey": "aep-proxy-managed",
+                "auth": "api-key",
+                "models": [],
+            },
+        )
+        cost = m.get("cost_per_million_tokens") or {}
+        provider["models"].append(
+            {
+                "id": m["id"],
+                "name": m["id"],
+                "reasoning": False,
+                "input": m.get("modalities") or ["text"],
+                "cost": {
+                    "input": cost.get("input", 0),
+                    "output": cost.get("output", 0),
+                    "cacheRead": cost.get("cache_read", 0),
+                    "cacheWrite": cost.get("cache_write", 0),
+                },
+                "contextWindow": m.get("context_window", 128000),
+                "maxTokens": m.get("max_output_tokens", 16384),
+            }
+        )
+    return providers
+
+
+def _splice_into_existing(
+    existing: dict[str, Any], providers: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    """Insert the new providers map into an existing openclaw.json structure.
+
+    Preserves everything outside ``models.providers`` so users keep their
+    ``gateway``, ``agents.defaults``, ``plugins`` etc. ``models.mode`` is
+    forced to ``"replace"`` so OpenClaw doesn't merge our list with its
+    bundled 200-model default catalog (which contains models not routable
+    through AceTeam — would produce silent "incomplete terminal response"
+    failures).
+    """
+    out = dict(existing)
+    models_section = dict(out.get("models") or {})
+    models_section["mode"] = "replace"
+    models_section["providers"] = providers
+    out["models"] = models_section
+    meta = dict(out.get("meta") or {})
+    meta["lastTouchedAt"] = datetime.now(UTC).isoformat()
+    out["meta"] = meta
+    return out
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content via tmp+rename so a crash mid-write can't leave a half file."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    tmp.replace(path)
+
+
+async def refresh_openclaw_config(
+    *,
+    api_key: str,
+    target_base_url: str,
+    config_path: str,
+) -> dict[str, Any]:
+    """Fetch /v1/models, write openclaw.json, return a status record.
+
+    The status record is what gets surfaced via the dashboard so users see
+    when a sync ran, how many models landed, and whether a restart is
+    needed for it to take effect.
+    """
+    status: dict[str, Any] = {
+        "ok": False,
+        "config_path": config_path,
+        "checked_at": datetime.now(UTC).isoformat(),
+    }
+
+    if not api_key.startswith("act_"):
+        status["error"] = "non-aceteam key (sync only supports act_* keys)"
+        return status
+
+    models_url = _resolve_models_url(target_base_url)
+    if models_url is None:
+        status["error"] = f"invalid target_base_url: {target_base_url!r}"
+        return status
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                models_url, headers={"Authorization": f"Bearer {api_key}"}
+            )
+    except Exception as err:  # noqa: BLE001 — network errors are part of the contract
+        log.warning("openclaw sync: gateway unreachable: %s", err)
+        status["error"] = f"gateway unreachable: {err}"
+        return status
+
+    if resp.status_code != 200:
+        log.warning(
+            "openclaw sync: gateway %s returned %d", models_url, resp.status_code
+        )
+        status["error"] = f"gateway returned HTTP {resp.status_code}"
+        return status
+
+    try:
+        body = resp.json()
+        models = body.get("data") or []
+    except (ValueError, AttributeError) as err:
+        status["error"] = f"malformed gateway response: {err}"
+        return status
+
+    if not models:
+        # Treat empty-catalog as a soft failure — usually means the org has
+        # no usable BYOK keys, so we shouldn't blow away a working config.
+        status["error"] = "gateway returned empty catalog (no usable models for this org)"
+        return status
+
+    providers = _transform_models_to_providers(models)
+
+    path_obj = Path(config_path)
+    if path_obj.exists():
+        try:
+            existing = json.loads(path_obj.read_text())
+        except (OSError, json.JSONDecodeError) as err:
+            log.warning("openclaw sync: existing config unreadable, starting fresh: %s", err)
+            existing = {"gateway": {"mode": "local"}}
+    else:
+        existing = {"gateway": {"mode": "local"}}
+
+    new_config = _splice_into_existing(existing, providers)
+
+    try:
+        _atomic_write(path_obj, json.dumps(new_config, indent=2) + "\n")
+    except OSError as err:
+        log.warning("openclaw sync: write failed: %s", err)
+        status["error"] = f"write failed: {err}"
+        return status
+
+    log.info(
+        "openclaw sync: wrote %d models across %d providers to %s",
+        len(models),
+        len(providers),
+        config_path,
+    )
+    status.update(
+        {
+            "ok": True,
+            "model_count": len(models),
+            "providers": sorted(providers.keys()),
+            "written_at": status["checked_at"],
+            "restart_required": True,
+        }
+    )
+    return status
+
+
+__all__ = ["get_configured_path", "refresh_openclaw_config"]

--- a/tests/test_openclaw_sync.py
+++ b/tests/test_openclaw_sync.py
@@ -1,0 +1,484 @@
+"""Tests for the openclaw.json auto-sync from /v1/models."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aceteam_aep.proxy.openclaw_sync import (
+    _splice_into_existing,
+    _transform_models_to_providers,
+    get_configured_path,
+    refresh_openclaw_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("AEP_OPENCLAW_CONFIG_PATH", raising=False)
+    yield
+
+
+def _gateway_models_response(models: list[dict]) -> dict:
+    return {"object": "list", "data": models}
+
+
+def _make_resp(status_code: int, body: dict | None = None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=body or {})
+    return resp
+
+
+def _patch_httpx(resp_or_exc):
+    """Patch httpx.AsyncClient to return resp on .get(), or raise an exception."""
+    mock_client = AsyncMock()
+    if isinstance(resp_or_exc, Exception):
+        mock_client.get = AsyncMock(side_effect=resp_or_exc)
+    else:
+        mock_client.get = AsyncMock(return_value=resp_or_exc)
+
+    async def _aenter(self):
+        return mock_client
+
+    async def _aexit(self, *_):
+        return None
+
+    return patch("httpx.AsyncClient.__aenter__", _aenter), patch(
+        "httpx.AsyncClient.__aexit__", _aexit
+    ), mock_client
+
+
+class TestGetConfiguredPath:
+    def test_returns_none_when_unset(self) -> None:
+        assert get_configured_path() is None
+
+    def test_returns_path_when_set(self, monkeypatch) -> None:
+        monkeypatch.setenv("AEP_OPENCLAW_CONFIG_PATH", "/openclaw-config/openclaw.json")
+        assert get_configured_path() == "/openclaw-config/openclaw.json"
+
+    def test_strips_whitespace(self, monkeypatch) -> None:
+        monkeypatch.setenv("AEP_OPENCLAW_CONFIG_PATH", "  /a/b.json  ")
+        assert get_configured_path() == "/a/b.json"
+
+
+class TestTransformModelsToProviders:
+    def test_groups_by_owned_by(self) -> None:
+        out = _transform_models_to_providers(
+            [
+                {
+                    "id": "gpt-4o",
+                    "owned_by": "openai",
+                    "context_window": 128000,
+                    "max_output_tokens": 16384,
+                    "modalities": ["text", "image"],
+                    "cost_per_million_tokens": {
+                        "input": 2.5,
+                        "output": 10,
+                        "cache_read": 1.25,
+                        "cache_write": 0,
+                    },
+                },
+                {
+                    "id": "gpt-4o-mini",
+                    "owned_by": "openai",
+                    "context_window": 128000,
+                    "max_output_tokens": 16384,
+                    "modalities": ["text"],
+                    "cost_per_million_tokens": {
+                        "input": 0.15,
+                        "output": 0.6,
+                        "cache_read": 0.075,
+                        "cache_write": 0,
+                    },
+                },
+                {
+                    "id": "tr-deepseek-v4-pro",
+                    "owned_by": "deepseek",
+                    "context_window": 128000,
+                    "max_output_tokens": 16384,
+                    "modalities": ["text"],
+                    "cost_per_million_tokens": {
+                        "input": 1.74,
+                        "output": 3.48,
+                        "cache_read": 0.145,
+                        "cache_write": 0,
+                    },
+                },
+            ]
+        )
+        assert set(out.keys()) == {"openai", "deepseek"}
+        assert len(out["openai"]["models"]) == 2
+        assert {m["id"] for m in out["openai"]["models"]} == {"gpt-4o", "gpt-4o-mini"}
+        assert out["deepseek"]["models"][0]["id"] == "tr-deepseek-v4-pro"
+        assert out["openai"]["baseUrl"] == "http://aep-proxy:8899/v1"
+        assert out["openai"]["apiKey"] == "aep-proxy-managed"
+
+    def test_preserves_modalities_and_cost_shape(self) -> None:
+        out = _transform_models_to_providers(
+            [
+                {
+                    "id": "x",
+                    "owned_by": "openai",
+                    "context_window": 200000,
+                    "max_output_tokens": 8192,
+                    "modalities": ["text", "image", "audio"],
+                    "cost_per_million_tokens": {
+                        "input": 1,
+                        "output": 2,
+                        "cache_read": 0.1,
+                        "cache_write": 0.5,
+                    },
+                }
+            ]
+        )
+        m = out["openai"]["models"][0]
+        assert m["input"] == ["text", "image", "audio"]
+        assert m["cost"] == {
+            "input": 1,
+            "output": 2,
+            "cacheRead": 0.1,
+            "cacheWrite": 0.5,
+        }
+        assert m["contextWindow"] == 200000
+        assert m["maxTokens"] == 8192
+
+    def test_handles_missing_optional_fields(self) -> None:
+        """Models with no modalities / no cost fields shouldn't blow up."""
+        out = _transform_models_to_providers(
+            [
+                {
+                    "id": "minimal",
+                    # owned_by absent → "unknown"
+                    # modalities absent → ["text"]
+                    # cost_per_million_tokens absent → zeros
+                }
+            ]
+        )
+        m = out["unknown"]["models"][0]
+        assert m["input"] == ["text"]
+        assert m["cost"]["input"] == 0
+        assert m["contextWindow"] == 128000
+
+
+class TestSpliceIntoExisting:
+    def test_preserves_unrelated_sections(self) -> None:
+        existing = {
+            "gateway": {"mode": "local"},
+            "agents": {"defaults": {"model": {"primary": "openai/gpt-4o"}}},
+            "plugins": {"entries": {"openai": {"enabled": True}}},
+            "models": {"providers": {"oldstuff": "should be replaced"}},
+            "meta": {"keep": "this"},
+        }
+        out = _splice_into_existing(existing, {"openai": {"baseUrl": "x", "models": []}})
+        assert out["gateway"] == existing["gateway"]
+        assert out["agents"] == existing["agents"]
+        assert out["plugins"] == existing["plugins"]
+        # models.providers is replaced wholesale
+        assert out["models"]["providers"] == {"openai": {"baseUrl": "x", "models": []}}
+        # mode forced to "replace" so OpenClaw doesn't merge bundled defaults
+        assert out["models"]["mode"] == "replace"
+        # meta.keep retained, lastTouchedAt added
+        assert out["meta"]["keep"] == "this"
+        assert "lastTouchedAt" in out["meta"]
+
+    def test_handles_missing_models_section(self) -> None:
+        existing = {"gateway": {"mode": "local"}}
+        out = _splice_into_existing(existing, {"openai": {"models": []}})
+        assert out["models"]["mode"] == "replace"
+        assert out["models"]["providers"] == {"openai": {"models": []}}
+
+
+class TestRefreshOpenclawConfig:
+    @pytest.mark.asyncio
+    async def test_writes_file_on_success(self, tmp_path) -> None:
+        target = tmp_path / "openclaw.json"
+        target.write_text(json.dumps({"gateway": {"mode": "local"}}))
+
+        resp = _make_resp(
+            200,
+            _gateway_models_response(
+                [
+                    {
+                        "id": "tr-deepseek-v4-pro",
+                        "owned_by": "deepseek",
+                        "context_window": 128000,
+                        "max_output_tokens": 16384,
+                        "modalities": ["text"],
+                        "cost_per_million_tokens": {
+                            "input": 1.74,
+                            "output": 3.48,
+                            "cache_read": 0.145,
+                            "cache_write": 0,
+                        },
+                    }
+                ]
+            ),
+        )
+        p1, p2, mock_client = _patch_httpx(resp)
+        with p1, p2:
+            status = await refresh_openclaw_config(
+                api_key="act_xxxxxxxxxxxxxxxx",
+                target_base_url="https://aceteam.ai/api/gateway",
+                config_path=str(target),
+            )
+
+        assert status["ok"] is True
+        assert status["model_count"] == 1
+        assert status["restart_required"] is True
+
+        written = json.loads(target.read_text())
+        assert written["models"]["mode"] == "replace"
+        assert "deepseek" in written["models"]["providers"]
+        assert written["gateway"] == {"mode": "local"}  # preserved
+
+        # Confirm the gateway URL was constructed correctly.
+        assert (
+            mock_client.get.await_args.args[0]
+            == "https://aceteam.ai/api/gateway/v1/models"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_for_non_act_keys(self, tmp_path) -> None:
+        target = tmp_path / "openclaw.json"
+        original = {"gateway": {"mode": "local"}}
+        target.write_text(json.dumps(original))
+
+        status = await refresh_openclaw_config(
+            api_key="sk-openai-xyz",
+            target_base_url="https://aceteam.ai/api/gateway",
+            config_path=str(target),
+        )
+        assert status["ok"] is False
+        assert "non-aceteam" in status["error"].lower()
+        # File untouched
+        assert json.loads(target.read_text()) == original
+
+    @pytest.mark.asyncio
+    async def test_does_not_clobber_when_catalog_empty(self, tmp_path) -> None:
+        """Gateway returning 0 models = soft-fail; preserve the existing config."""
+        target = tmp_path / "openclaw.json"
+        original = {
+            "gateway": {"mode": "local"},
+            "models": {
+                "mode": "replace",
+                "providers": {"openai": {"models": [{"id": "gpt-4o"}]}},
+            },
+        }
+        target.write_text(json.dumps(original))
+
+        resp = _make_resp(200, _gateway_models_response([]))
+        p1, p2, _client = _patch_httpx(resp)
+        with p1, p2:
+            status = await refresh_openclaw_config(
+                api_key="act_xxxxxxxxxxxxxxxx",
+                target_base_url="https://aceteam.ai/api/gateway",
+                config_path=str(target),
+            )
+
+        assert status["ok"] is False
+        assert "empty" in status["error"].lower()
+        assert json.loads(target.read_text()) == original
+
+    @pytest.mark.asyncio
+    async def test_handles_gateway_5xx(self, tmp_path) -> None:
+        target = tmp_path / "openclaw.json"
+        target.write_text("{}")
+        resp = _make_resp(503)
+        p1, p2, _ = _patch_httpx(resp)
+        with p1, p2:
+            status = await refresh_openclaw_config(
+                api_key="act_xxxxxxxxxxxxxxxx",
+                target_base_url="https://aceteam.ai/api/gateway",
+                config_path=str(target),
+            )
+        assert status["ok"] is False
+        assert "503" in status["error"]
+
+    @pytest.mark.asyncio
+    async def test_handles_network_failure(self, tmp_path) -> None:
+        target = tmp_path / "openclaw.json"
+        target.write_text("{}")
+        p1, p2, _ = _patch_httpx(ConnectionError("dns refused"))
+        with p1, p2:
+            status = await refresh_openclaw_config(
+                api_key="act_xxxxxxxxxxxxxxxx",
+                target_base_url="https://aceteam.ai/api/gateway",
+                config_path=str(target),
+            )
+        assert status["ok"] is False
+        assert "unreachable" in status["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_handles_invalid_target_base_url(self, tmp_path) -> None:
+        target = tmp_path / "openclaw.json"
+        target.write_text("{}")
+        status = await refresh_openclaw_config(
+            api_key="act_xxxxxxxxxxxxxxxx",
+            target_base_url="not-a-url",
+            config_path=str(target),
+        )
+        assert status["ok"] is False
+        assert "invalid" in status["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_creates_file_when_absent(self, tmp_path) -> None:
+        """Fresh install: no openclaw.json yet — should still write a valid one."""
+        target = tmp_path / "subdir" / "openclaw.json"
+        target.parent.mkdir()  # parent must exist for the rename
+        # File does not yet exist.
+
+        resp = _make_resp(
+            200,
+            _gateway_models_response(
+                [
+                    {
+                        "id": "x",
+                        "owned_by": "openai",
+                        "context_window": 1,
+                        "max_output_tokens": 1,
+                        "modalities": ["text"],
+                        "cost_per_million_tokens": {
+                            "input": 0,
+                            "output": 0,
+                            "cache_read": 0,
+                            "cache_write": 0,
+                        },
+                    }
+                ]
+            ),
+        )
+        p1, p2, _ = _patch_httpx(resp)
+        with p1, p2:
+            status = await refresh_openclaw_config(
+                api_key="act_xxxxxxxxxxxxxxxx",
+                target_base_url="https://aceteam.ai/api/gateway",
+                config_path=str(target),
+            )
+
+        assert status["ok"] is True
+        assert target.exists()
+        written = json.loads(target.read_text())
+        # Default scaffold added
+        assert written["gateway"] == {"mode": "local"}
+        assert "openai" in written["models"]["providers"]
+
+
+class TestApiKeyHandlerWiring:
+    """Verify the api-key handler triggers sync iff AEP_OPENCLAW_CONFIG_PATH is set."""
+
+    def _build_app(self):
+        from starlette.testclient import TestClient
+
+        from aceteam_aep.proxy.app import create_proxy_app
+        from aceteam_aep.safety.base import SafetyDetector
+
+        class _Noop(SafetyDetector):
+            name = "noop"
+
+            async def check(self, **kwargs):
+                return ()
+
+        app = create_proxy_app(detectors=[_Noop()], dashboard=True)
+        return app, TestClient(app)
+
+    def test_status_endpoint_reports_disabled_when_env_unset(self) -> None:
+        _app, client = self._build_app()
+        body = client.get("/dashboard/api/openclaw-config-status").json()
+        assert body["enabled"] is False
+        assert body["status"] is None
+
+    def test_status_endpoint_reports_enabled_when_env_set(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv("AEP_OPENCLAW_CONFIG_PATH", str(tmp_path / "openclaw.json"))
+        _app, client = self._build_app()
+        body = client.get("/dashboard/api/openclaw-config-status").json()
+        assert body["enabled"] is True
+        assert body["config_path"] == str(tmp_path / "openclaw.json")
+        assert body["status"] is None  # no sync attempt yet
+
+    def test_post_api_key_triggers_sync_when_env_set(self, monkeypatch, tmp_path) -> None:
+        target = tmp_path / "openclaw.json"
+        target.write_text(json.dumps({"gateway": {"mode": "local"}}))
+        monkeypatch.setenv("AEP_OPENCLAW_CONFIG_PATH", str(target))
+
+        _app, client = self._build_app()
+
+        # Mock both the whoami refresh and the /v1/models fetch — the api-key
+        # handler triggers _refresh_connected_account first, then sync.
+        whoami_resp = _make_resp(
+            200,
+            {
+                "auth_type": "api_key",
+                "email": "u@example.com",
+                "organization_id": "org_xyz",
+                "organization_name": "Acme",
+            },
+        )
+        models_resp = _make_resp(
+            200,
+            _gateway_models_response(
+                [
+                    {
+                        "id": "tr-deepseek-v4-pro",
+                        "owned_by": "deepseek",
+                        "context_window": 128000,
+                        "max_output_tokens": 16384,
+                        "modalities": ["text"],
+                        "cost_per_million_tokens": {
+                            "input": 1.74,
+                            "output": 3.48,
+                            "cache_read": 0.145,
+                            "cache_write": 0,
+                        },
+                    }
+                ]
+            ),
+        )
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[whoami_resp, models_resp])
+
+        async def _aenter(self):
+            return mock_client
+
+        async def _aexit(self, *_):
+            return None
+
+        with (
+            patch("httpx.AsyncClient.__aenter__", _aenter),
+            patch("httpx.AsyncClient.__aexit__", _aexit),
+        ):
+            saved = client.post(
+                "/dashboard/api/api-key",
+                json={
+                    "api_key": "act_xxxxxxxxxxxxxxxx",
+                    "base_url": "http://aceteam.local/api/gateway",
+                },
+            ).json()
+
+        assert saved["set"] is True
+
+        # File got rewritten with the synced catalog.
+        written = json.loads(target.read_text())
+        assert "deepseek" in written["models"]["providers"]
+        assert written["models"]["mode"] == "replace"
+
+        # Status endpoint surfaces success
+        status = client.get("/dashboard/api/openclaw-config-status").json()
+        assert status["enabled"] is True
+        assert status["status"]["ok"] is True
+        assert status["status"]["model_count"] == 1
+        assert status["status"]["restart_required"] is True
+
+    def test_post_api_key_skips_sync_when_env_unset(self, tmp_path) -> None:
+        """Without AEP_OPENCLAW_CONFIG_PATH, no sync attempt — status stays None."""
+        _app, client = self._build_app()
+        # No env set, no httpx mocking — sync path must be skipped before hitting network.
+        client.post(
+            "/dashboard/api/api-key",
+            json={"api_key": "sk-byok-only"},
+        )
+        status = client.get("/dashboard/api/openclaw-config-status").json()
+        assert status["enabled"] is False
+        assert status["status"] is None


### PR DESCRIPTION
## Summary

When the SafeClaw user connects via the dashboard, an act_* key lands in ProxyState. This PR makes the proxy fetch /v1/models from the AceTeam gateway right after that, transform the OpenAI-shape catalog into OpenClaw's `models.providers` shape, and write it into openclaw.json — so the model picker stays in sync with the live AceTeam catalog automatically.

Pairs with [aceteam-ai/safeclaw#TBD](https://github.com/aceteam-ai/safeclaw/pull/new/feat/auto-sync-openclaw-models) which adds the bind mount + env var that activate this code path. Without that compose change, the new module is dormant (env-gated).

## Why

Up to now, openclaw.json's model list was a static seed in `safeclaw-site/install.sh`. Adding a new TokenRouter model meant editing the catalog AND each install. With the PR landed, /v1/models on the gateway is the single source of truth (Supabase-backed, org-filtered) and the proxy mirrors it into the user's OpenClaw config on every connect.

## Architecture

- New module `proxy/openclaw_sync.py` — fetch + transform + atomic write, isolated from app.py
- Wired into `api_key_handler` POST after `_refresh_connected_account`. Skips entirely when `AEP_OPENCLAW_CONFIG_PATH` is unset
- Skips for non-act_* keys (BYOK users without an AceTeam org have nothing to mirror)
- Empty-catalog response treated as soft-fail to avoid clobbering a working config when the gateway has a transient issue
- Atomic write via tmp+rename so a crash mid-write can't leave a half-file
- New `GET /dashboard/api/openclaw-config-status` surfaces last sync result so the dashboard can render a "restart gateway to apply" banner

## Trade-off: restart still manual

OpenClaw doesn't hot-reload openclaw.json (verified by experiment). This PR writes the file but doesn't restart the gateway — change appears on the next compose restart. Status carries `restart_required: true` so the dashboard can prompt. Auto-restart would need either a docker socket mount in the proxy (security increase) or a HUP-signal hook in OpenClaw upstream — both worse than a one-line user action.

## Test plan

- [x] `uv run pytest tests/test_openclaw_sync.py` — 19/19 pass (env gating, transformation, splice idempotency, network failure modes, empty-catalog soft-fail, fresh-install scaffold, status endpoint enabled/disabled, full POST→sync→status round-trip)
- [x] Existing `tests/test_custom_policies_api.py -k api_key` — 8/8 still pass (auto-sync skipped because AEP_OPENCLAW_CONFIG_PATH unset)
- [x] `uv run ruff check src/aceteam_aep/proxy/openclaw_sync.py src/aceteam_aep/proxy/app.py` — clean
- [ ] After both PRs merge: connect via SafeClaw dashboard, confirm openclaw.json gets the new tr-* models, banner surfaces, gateway restart picks them up

🤖 Generated with [Claude Code](https://claude.com/claude-code)