### PR TITLE
fix(streaming): handle max_tokens truncation of tool calls

### DIFF
--- a/src/aceteam_aep/agent.py
+++ b/src/aceteam_aep/agent.py
@@ -300,9 +300,32 @@ async def run_agent_loop_stream(
             )
             working.append(assistant_msg)
 
-            # No tool calls → done
+            # No tool calls -> done
             if not accumulated_tool_calls:
                 break
+
+            # If the response was truncated by max_tokens, tool call arguments
+            # are likely incomplete (truncated JSON).  Rather than executing
+            # broken calls or giving up, remove the partial assistant message
+            # and ask the model to retry with a more concise approach.
+            if last_finish_reason == "max_tokens":
+                working.pop()  # remove partial assistant message
+                working.append(
+                    ChatMessage(
+                        role="user",
+                        content=(
+                            "Your previous response was cut off because it exceeded the "
+                            "output token limit. Please try again with a more concise "
+                            "version. If the content is too large for a single tool call, "
+                            "split it into smaller parts across multiple calls."
+                        ),
+                    )
+                )
+                yield chunk_event(
+                    "[Retrying -- previous response exceeded token limit]\n\n"
+                )
+                last_finish_reason = None
+                continue
 
             # Execute tool calls
             for tc in accumulated_tool_calls:

--- a/src/aceteam_aep/providers/anthropic.py
+++ b/src/aceteam_aep/providers/anthropic.py
@@ -278,6 +278,26 @@ class AnthropicClient:
                         output_tokens = event.usage.output_tokens
                     finish = getattr(event.delta, "stop_reason", None)
                     if finish:
+                        # Flush any in-progress tool call that was truncated
+                        # (e.g. by max_tokens). Anthropic skips content_block_stop
+                        # when the response is cut short, so the accumulated
+                        # partial JSON would otherwise be silently dropped.
+                        if current_tool:
+                            try:
+                                raw_args = current_tool["arguments"]
+                                args = json.loads(raw_args) if raw_args.strip() else {}
+                            except (json.JSONDecodeError, TypeError):
+                                args = {"raw": current_tool["arguments"]}
+                            yield StreamChunk(
+                                delta_tool_calls=[
+                                    ToolCallRequest(
+                                        id=current_tool["id"],
+                                        name=current_tool["name"],
+                                        arguments=args,
+                                    )
+                                ]
+                            )
+                            current_tool = None
                         yield StreamChunk(
                             finish_reason=finish,
                             usage=Usage(


### PR DESCRIPTION
## Context

The Mini App Builder on aceteam.ai was producing empty responses for code-heavy prompts like "make a first person shooter game like wolf3d". The model generated 8,192 tokens but the user saw nothing — no text, no tool calls, no error. Cost was charged ($0.13/run) with zero output.

## Summary

**Root cause**: Anthropic's streaming API skips `content_block_stop` when `max_tokens` truncates a response mid-tool-call. The AEP Anthropic provider only yielded tool call data on `content_block_stop`, so when the stop event was skipped, all accumulated tool call content (the entire HTML app code) was silently dropped.

**Anthropic provider fix** (`providers/anthropic.py`): When `message_delta` arrives with a `stop_reason`, flush any in-progress `current_tool` before yielding the finish chunk. This ensures partial tool calls are surfaced instead of silently lost.

**Agent loop fix** (`agent.py`): When `finish_reason == "max_tokens"` and there are accumulated tool calls (with likely-incomplete JSON arguments), don't execute them or give up. Instead, pop the partial assistant message and add a guidance prompt asking the model to retry with a more concise version. The loop continues automatically.

## Test plan

| Test | Result |
|------|--------|
| Wolf3d prompt with 8192 max_tokens — truncation detected, partial tool call flushed | Verified via curl |
| Auto-continue retry — model retries with concise version after truncation | Verified via curl |
| Wolf3d prompt with 32000 max_tokens — completes without truncation (11.5K tokens) | Verified via curl |
| Pong game prompt — full tool call + execution + text response | Verified end-to-end, app deployed |

---
*Generated by Claude*