### PR TITLE
fix(packaging): split programasweights into custom-policies extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ The gateway runs a single process on one port with three interfaces:
 ## Installation
 
 ```bash
-pip install aceteam-aep[all]               # Everything (recommended)
-pip install aceteam-aep[safety,proxy]      # Safety detectors + proxy
-pip install aceteam-aep                    # Core only (cost tracking + regex safety)
+pip install aceteam-aep[all]                       # Everything (recommended)
+pip install aceteam-aep[proxy,safety]              # Proxy + ML detectors (PII, content safety)
+pip install aceteam-aep[proxy,custom-policies]     # Proxy + natural-language policies (PAW)
+pip install aceteam-aep[proxy]                     # Lightweight proxy: regex + threshold detectors only
+pip install aceteam-aep                            # Core: cost tracking + regex safety
 ```
+
+The `safety` extra pulls in `transformers` + `torch` (ML detectors). The `custom-policies`
+extra pulls in `programasweights` (natural-language policy compilation, large native build).
+Both are opt-in so a default `[proxy]` install stays slim.
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ ollama = ["ollama>=0.4.0,<1.0.0"]
 # Heavyweight: large native build, platform-sensitive. Opt-in only.
 custom-policies = ["programasweights>=0.4.2"]
 # ML-based PII / content-safety detectors (transformers + torch).
-safety = ["transformers>=4.40", "torch>=2.0"]
+# Includes custom-policies for backward compat — pre-split [safety] users
+# had programasweights bundled in, and we don't want them silently losing
+# custom-policy support after upgrade.
+safety = ["aceteam-aep[custom-policies]", "transformers>=4.40", "torch>=2.0"]
 # Deprecated alias for custom-policies — kept so old installs don't break.
 safety_lite = ["aceteam-aep[custom-policies]"]
 dashboard = ["uvicorn>=0.30", "jinja2>=3.1", "starlette>=0.38"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,18 +29,26 @@ dependencies = [
 [project.optional-dependencies]
 xai = ["openai>=1.65.0,<2.0.0"]
 ollama = ["ollama>=0.4.0,<1.0.0"]
-safety = ["programasweights>=0.4.2", "transformers>=4.40", "torch>=2.0"]
-safety_lite = ["programasweights>=0.4.2"]
+# Natural-language custom policies (programasweights → llama-cpp-python).
+# Heavyweight: large native build, platform-sensitive. Opt-in only.
+custom-policies = ["programasweights>=0.4.2"]
+# ML-based PII / content-safety detectors (transformers + torch).
+safety = ["transformers>=4.40", "torch>=2.0"]
+# Deprecated alias for custom-policies — kept so old installs don't break.
+safety_lite = ["aceteam-aep[custom-policies]"]
 dashboard = ["uvicorn>=0.30", "jinja2>=3.1", "starlette>=0.38"]
 observability = ["aiosqlite>=0.20"]
-proxy = ["aceteam-aep[dashboard,safety_lite,observability]"]
+# Proxy stays lightweight: regex/threshold detectors (secrets, agent_threat,
+# cost_anomaly) work without ML deps. For ML-based detection install [proxy,safety];
+# for natural-language custom policies install [proxy,custom-policies].
+proxy = ["aceteam-aep[dashboard,observability]"]
 events = ["redis[hiredis]>=5.0"]
 mcp = ["fastmcp>=2.0"]
 yaml = ["pyyaml>=6.0"]
 feedback = ["lancedb>=0.30"]
 top = ["rich>=13.0"]
 all = [
-    "aceteam-aep[xai,ollama,safety,dashboard,proxy,yaml,mcp,feedback,top,events,observability]",
+    "aceteam-aep[xai,ollama,custom-policies,safety,dashboard,proxy,yaml,mcp,feedback,top,events,observability]",
 ]
 dev = [
     "aceteam-aep[all]",

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aceteam-aep"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -32,6 +32,9 @@ all = [
     { name = "torch" },
     { name = "transformers" },
     { name = "uvicorn" },
+]
+custom-policies = [
+    { name = "programasweights" },
 ]
 dashboard = [
     { name = "jinja2" },
@@ -77,12 +80,10 @@ ollama = [
 proxy = [
     { name = "aiosqlite" },
     { name = "jinja2" },
-    { name = "programasweights" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
 safety = [
-    { name = "programasweights" },
     { name = "torch" },
     { name = "transformers" },
 ]
@@ -102,8 +103,9 @@ yaml = [
 [package.metadata]
 requires-dist = [
     { name = "aceteam-aep", extras = ["all"], marker = "extra == 'dev'" },
-    { name = "aceteam-aep", extras = ["dashboard", "safety-lite", "observability"], marker = "extra == 'proxy'" },
-    { name = "aceteam-aep", extras = ["xai", "ollama", "safety", "dashboard", "proxy", "yaml", "mcp", "feedback", "top", "events", "observability"], marker = "extra == 'all'" },
+    { name = "aceteam-aep", extras = ["custom-policies"], marker = "extra == 'safety-lite'" },
+    { name = "aceteam-aep", extras = ["dashboard", "observability"], marker = "extra == 'proxy'" },
+    { name = "aceteam-aep", extras = ["xai", "ollama", "custom-policies", "safety", "dashboard", "proxy", "yaml", "mcp", "feedback", "top", "events", "observability"], marker = "extra == 'all'" },
     { name = "aiosqlite", marker = "extra == 'observability'", specifier = ">=0.20" },
     { name = "anthropic", specifier = ">=0.45.0,<1.0.0" },
     { name = "anyio", specifier = ">=4.12" },
@@ -117,8 +119,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.65.0,<2.0.0" },
     { name = "openai", marker = "extra == 'xai'", specifier = ">=1.65.0,<2.0.0" },
     { name = "overrides", specifier = ">=7.7.0" },
-    { name = "programasweights", marker = "extra == 'safety'", specifier = ">=0.4.2" },
-    { name = "programasweights", marker = "extra == 'safety-lite'", specifier = ">=0.4.2" },
+    { name = "programasweights", marker = "extra == 'custom-policies'", specifier = ">=0.4.2" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -132,7 +133,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'safety'", specifier = ">=4.40" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.30" },
 ]
-provides-extras = ["xai", "ollama", "safety", "safety-lite", "dashboard", "observability", "proxy", "events", "mcp", "yaml", "feedback", "top", "all", "dev"]
+provides-extras = ["xai", "ollama", "custom-policies", "safety", "safety-lite", "dashboard", "observability", "proxy", "events", "mcp", "yaml", "feedback", "top", "all", "dev"]
 
 [[package]]
 name = "aiofile"

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,7 @@ proxy = [
     { name = "uvicorn" },
 ]
 safety = [
+    { name = "programasweights" },
     { name = "torch" },
     { name = "transformers" },
 ]
@@ -103,6 +104,7 @@ yaml = [
 [package.metadata]
 requires-dist = [
     { name = "aceteam-aep", extras = ["all"], marker = "extra == 'dev'" },
+    { name = "aceteam-aep", extras = ["custom-policies"], marker = "extra == 'safety'" },
     { name = "aceteam-aep", extras = ["custom-policies"], marker = "extra == 'safety-lite'" },
     { name = "aceteam-aep", extras = ["dashboard", "observability"], marker = "extra == 'proxy'" },
     { name = "aceteam-aep", extras = ["xai", "ollama", "custom-policies", "safety", "dashboard", "proxy", "yaml", "mcp", "feedback", "top", "events", "observability"], marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary

- Drops `programasweights` (+ transitive `llama-cpp-python`) from the default `[proxy]` install
- Adds `custom-policies` extra; opt-in only when natural-language policies are wanted
- `[safety]` extra is now ML-only (`transformers` + `torch`); `[proxy]` is dashboard + observability
- `safety_lite` kept as backward-compat alias

## Why

`pip install aceteam-aep[proxy]` was pulling in a heavyweight native ML stack (`llama-cpp-python` via `programasweights`) even when users only wanted regex/threshold detectors (secrets, agent_threat, cost_anomaly). Those are pure-Python and don't need it.

`safety/custom.py` already lazy-imports `programasweights` inside method bodies, so the proxy boots cleanly without it — verified locally with \`python -c \"from aceteam_aep.proxy.app import create_proxy_app; ... ; print('programasweights loaded?', 'programasweights' in sys.modules)\"\` returning False.

## Install matrix after this change

\`\`\`
pip install aceteam-aep[proxy]                    # lightweight: dashboard + obs + regex detectors
pip install aceteam-aep[proxy,safety]             # adds ML detectors (PII, content)
pip install aceteam-aep[proxy,custom-policies]    # adds natural-language policies (PAW)
pip install aceteam-aep[all]                      # everything
\`\`\`

## Test plan

- [x] \`uv sync --extra dev\` resolves cleanly
- [x] \`from aceteam_aep.proxy.app import create_proxy_app\` works without programasweights loading
- [x] tests/test_proxy.py + tests/test_safety pass (75/76 — the 1 deselected failure is pre-existing on main, unrelated to this change)
- [ ] After merge: bump to next minor since extras semantics changed

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)