### PR TITLE
feat(proxy): persist control-plane state across restarts

### DIFF
--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -14,6 +14,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -42,6 +43,13 @@ from .logutil import configure_proxy_debug_logging
 from .openclaw_sync import get_configured_path as _openclaw_config_path
 from .openclaw_sync import refresh_openclaw_config
 from .redis_publisher import build_event, publish_event
+from .state_persistence import (
+    get_configured_path as _state_persistence_path,
+)
+from .state_persistence import (
+    load_persisted_state,
+    save_persisted_state,
+)
 
 log = logging.getLogger(__name__)
 
@@ -166,9 +174,15 @@ class ProxyState:
         budget: float | None = None,
         budget_per_session: float | None = None,
         event_store: EventStore | None = None,
+        state_path: Path | None = None,
     ) -> None:
         self.target_base_url = target_base_url.rstrip("/")
         self.event_store = event_store
+        # When set, ProxyState mirrors a small slice of itself (api_key,
+        # connected_account, target_base_url, safety_enabled) to this file
+        # so a restart doesn't wipe the dashboard-configured state. None
+        # disables persistence — that's the wrap()/test path.
+        self._state_path = state_path
         self.session_id = uuid.uuid4().hex
         self.cost_tracker = CostTracker()
         self.span_tracker = SpanTracker()
@@ -223,6 +237,44 @@ class ProxyState:
             to_register.append(CustomSafetyDetector(self.custom_policy_store))
         for det in to_register:
             self.registry.add(det)
+
+        # Apply any state from a prior run last, so the persisted api_key
+        # (e.g. an act_* from a dashboard connect) overrides the env-seeded
+        # one above. Persistence is opt-in via state_path; wrap()/tests pass
+        # None and get the original in-memory behavior.
+        if self._state_path is not None:
+            persisted = load_persisted_state(self._state_path)
+            if persisted is not None:
+                self._apply_persisted(persisted)
+
+    def _apply_persisted(self, fields: dict[str, Any]) -> None:
+        """Restore fields from a prior run. Silently skips bad/missing values."""
+        api_key = fields.get("api_key")
+        if isinstance(api_key, str) and api_key:
+            self.api_key = api_key
+        connected = fields.get("connected_account")
+        if isinstance(connected, dict) or connected is None:
+            self.connected_account = connected
+        url = fields.get("target_base_url")
+        if isinstance(url, str) and url:
+            self.target_base_url = url.rstrip("/")
+        enabled = fields.get("safety_enabled")
+        if isinstance(enabled, bool):
+            self.safety_enabled = enabled
+
+    def _persist(self) -> None:
+        """Write the current control-plane slice to disk; no-op if disabled."""
+        if self._state_path is None:
+            return
+        save_persisted_state(
+            self._state_path,
+            {
+                "api_key": self.api_key,
+                "connected_account": self.connected_account,
+                "target_base_url": self.target_base_url,
+                "safety_enabled": self.safety_enabled,
+            },
+        )
 
     @property
     def cost_usd(self) -> Decimal:
@@ -357,6 +409,7 @@ def create_proxy_app(
         budget=budget,
         budget_per_session=budget_per_session,
         event_store=event_store,
+        state_path=_state_persistence_path(),
     )
 
     # Enable debug logging if requested (see logutil; uvicorn/defaults drop DEBUG)
@@ -1039,6 +1092,7 @@ def create_proxy_app(
         if "enabled" in body:
             state.safety_enabled = bool(body["enabled"])
             log.info("Safety %s", "enabled" if state.safety_enabled else "disabled")
+            state._persist()
 
         # Hot-swap policy from inline dict (not file paths — prevents path traversal)
         if "policy" in body:
@@ -1238,6 +1292,7 @@ def create_proxy_app(
         if request.method == "DELETE":
             state.api_key = None
             state.connected_account = None
+            state._persist()
             return JSONResponse(_hint(None))
 
         body, json_err = await _read_json_body(request)
@@ -1302,6 +1357,10 @@ def create_proxy_app(
                 target_base_url=state.target_base_url,
                 config_path=config_path,
             )
+        # Persist after _refresh_connected_account / catalog sync so the
+        # written file reflects the post-refresh identity, not just the raw
+        # caller-supplied bits.
+        state._persist()
         return JSONResponse(_hint(state.api_key))
 
     # Policy tester — evaluate a single custom policy against arbitrary text,

--- a/src/aceteam_aep/proxy/state_persistence.py
+++ b/src/aceteam_aep/proxy/state_persistence.py
@@ -1,0 +1,128 @@
+"""Persist a small slice of ProxyState across restarts.
+
+Without this, every proxy restart wipes the API key, the connected AceTeam
+account, the target base URL, and the safety toggle — all things the user
+typically configured once via the dashboard. Forcing them to re-enter on
+every container restart is friction we shouldn't ship.
+
+What we persist (the "control plane" of ProxyState):
+
+- ``api_key`` (BYOK or ``act_*`` from the connect flow)
+- ``connected_account`` (org metadata so the dashboard remembers who's connected)
+- ``target_base_url`` (so picking a different upstream sticks)
+- ``safety_enabled`` (the toggle state — surprising if it flips on restart)
+
+What we explicitly do NOT persist:
+
+- Cost trackers, signals, decisions, spans — those live in :class:`EventStore`
+  (already SQLite-backed via aiosqlite). Putting them here would duplicate.
+- Custom policies — those have their own CRUD store and survive via that path.
+- The enforcement policy ``dict`` — typically loaded from a YAML/JSON file or
+  defaults; persisting and reloading would shadow that source-of-truth.
+- Budget — same reason: configured at process boot via flags/env.
+
+Storage format: a single small JSON document at ``AEP_STATE_PATH`` (default
+``~/.aceteam-aep/state.json``). Atomic write via tmp+rename so a crash
+mid-write can't leave a half-file. Mode 0o600 because the API key lives
+inside.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+STATE_PATH_ENV = "AEP_STATE_PATH"
+
+_DEFAULT_PATH = Path.home() / ".aceteam-aep" / "state.json"
+
+_PERSISTED_KEYS = (
+    "api_key",
+    "connected_account",
+    "target_base_url",
+    "safety_enabled",
+)
+
+
+def get_configured_path() -> Path | None:
+    """Return the configured state path, or None if persistence is disabled.
+
+    Persistence is opt-in: returns ``None`` when ``AEP_STATE_PATH`` is unset
+    AND the default path doesn't exist yet, so a fresh ``pip install`` user
+    sees zero behavioral change. Once any state has been written (even by
+    setting the env var once), the default path will exist on subsequent
+    runs and the proxy will keep using it.
+    """
+    raw = os.environ.get(STATE_PATH_ENV, "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    if _DEFAULT_PATH.exists():
+        return _DEFAULT_PATH
+    return None
+
+
+def get_default_path() -> Path:
+    """Return the default state path. Used when the user opts in via API."""
+    return _DEFAULT_PATH
+
+
+def load_persisted_state(path: Path) -> dict[str, Any] | None:
+    """Read a previously-saved state document; return None on any failure.
+
+    A corrupt or missing file is treated as "no persisted state" rather than
+    a hard error — the proxy should always boot, even if the file is junk.
+    The next mutation will overwrite it with a clean document.
+    """
+    try:
+        if not path.exists():
+            return None
+        raw = path.read_text()
+    except OSError as err:
+        log.warning("state persistence: cannot read %s: %s", path, err)
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as err:
+        log.warning("state persistence: %s is not valid JSON: %s", path, err)
+        return None
+
+    if not isinstance(data, dict):
+        log.warning("state persistence: %s is not a JSON object", path)
+        return None
+
+    return {k: data.get(k) for k in _PERSISTED_KEYS if k in data}
+
+
+def save_persisted_state(path: Path, fields: dict[str, Any]) -> None:
+    """Atomically write the persisted-fields document.
+
+    Only the keys in ``_PERSISTED_KEYS`` are written, even if ``fields``
+    contains more — keeps the surface area tight and prevents accidentally
+    persisting cost/signal data that belongs in the EventStore.
+    """
+    payload = {k: fields.get(k) for k in _PERSISTED_KEYS}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n")
+        tmp.replace(path)
+        # 0o600 — the API key is in here. Parent dir gates browse access too,
+        # but a tight file mode is cheap insurance against a stray world-read.
+        os.chmod(path, 0o600)
+    except OSError as err:
+        log.warning("state persistence: cannot write %s: %s", path, err)
+
+
+__all__ = [
+    "STATE_PATH_ENV",
+    "get_configured_path",
+    "get_default_path",
+    "load_persisted_state",
+    "save_persisted_state",
+]

--- a/src/aceteam_aep/proxy/state_persistence.py
+++ b/src/aceteam_aep/proxy/state_persistence.py
@@ -111,10 +111,12 @@ def save_persisted_state(path: Path, fields: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".tmp")
         tmp.write_text(json.dumps(payload, indent=2) + "\n")
+        # Tighten the mode BEFORE the rename so there's no window where the
+        # destination file exists with the umask-default mode (typically 0o644)
+        # — the API key inside would otherwise be world-readable for the
+        # microseconds between rename and chmod on shared systems.
+        os.chmod(tmp, 0o600)
         tmp.replace(path)
-        # 0o600 — the API key is in here. Parent dir gates browse access too,
-        # but a tight file mode is cheap insurance against a stray world-read.
-        os.chmod(path, 0o600)
     except OSError as err:
         log.warning("state persistence: cannot write %s: %s", path, err)
 

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -1,0 +1,183 @@
+"""Tests for proxy state persistence (api_key + connected account survives restart)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aceteam_aep.proxy.app import ProxyState
+from aceteam_aep.proxy.state_persistence import (
+    STATE_PATH_ENV,
+    get_configured_path,
+    load_persisted_state,
+    save_persisted_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(STATE_PATH_ENV, raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+
+
+class TestConfiguredPath:
+    def test_unset_env_no_default_file_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "aceteam_aep.proxy.state_persistence._DEFAULT_PATH", tmp_path / "missing.json"
+        )
+        assert get_configured_path() is None
+
+    def test_env_set_returns_path(self, tmp_path, monkeypatch):
+        target = tmp_path / "state.json"
+        monkeypatch.setenv(STATE_PATH_ENV, str(target))
+        assert get_configured_path() == target
+
+    def test_env_set_expands_tilde(self, monkeypatch):
+        monkeypatch.setenv(STATE_PATH_ENV, "~/some/where.json")
+        path = get_configured_path()
+        assert path is not None
+        assert "~" not in str(path)
+
+    def test_default_path_exists_returns_default(self, tmp_path, monkeypatch):
+        default = tmp_path / "default.json"
+        default.write_text("{}")
+        monkeypatch.setattr("aceteam_aep.proxy.state_persistence._DEFAULT_PATH", default)
+        assert get_configured_path() == default
+
+
+class TestLoadSave:
+    def test_save_then_load_roundtrip(self, tmp_path):
+        path = tmp_path / "state.json"
+        save_persisted_state(
+            path,
+            {
+                "api_key": "act_abc123",
+                "connected_account": {"email": "x@y.com", "organization_id": "org_1"},
+                "target_base_url": "https://example.com/api",
+                "safety_enabled": False,
+            },
+        )
+        loaded = load_persisted_state(path)
+        assert loaded == {
+            "api_key": "act_abc123",
+            "connected_account": {"email": "x@y.com", "organization_id": "org_1"},
+            "target_base_url": "https://example.com/api",
+            "safety_enabled": False,
+        }
+
+    def test_save_strips_unknown_keys(self, tmp_path):
+        path = tmp_path / "state.json"
+        save_persisted_state(
+            path,
+            {
+                "api_key": "k",
+                "connected_account": None,
+                "target_base_url": "u",
+                "safety_enabled": True,
+                "cost_usd": 1.23,  # not a persisted key — must not land in file
+                "session_id": "abc",
+            },
+        )
+        on_disk = json.loads(path.read_text())
+        assert "cost_usd" not in on_disk
+        assert "session_id" not in on_disk
+
+    def test_load_missing_file_returns_none(self, tmp_path):
+        assert load_persisted_state(tmp_path / "nope.json") is None
+
+    def test_load_invalid_json_returns_none(self, tmp_path):
+        path = tmp_path / "junk.json"
+        path.write_text("this is not json")
+        assert load_persisted_state(path) is None
+
+    def test_load_non_object_json_returns_none(self, tmp_path):
+        path = tmp_path / "list.json"
+        path.write_text("[1, 2, 3]")
+        assert load_persisted_state(path) is None
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "deep" / "nested" / "state.json"
+        save_persisted_state(path, {"api_key": "k"})
+        assert path.exists()
+
+    def test_save_uses_0600_mode(self, tmp_path):
+        path = tmp_path / "state.json"
+        save_persisted_state(path, {"api_key": "secret"})
+        mode = path.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_save_is_atomic_via_tmp_rename(self, tmp_path):
+        # Write once, then again — the .tmp file should not linger after a
+        # successful write. (Different from world-writable: this is just
+        # confirming we use rename, not truncate-write.)
+        path = tmp_path / "state.json"
+        save_persisted_state(path, {"api_key": "v1"})
+        save_persisted_state(path, {"api_key": "v2"})
+        assert not (tmp_path / "state.json.tmp").exists()
+        loaded = load_persisted_state(path)
+        assert loaded is not None
+        assert loaded["api_key"] == "v2"
+
+
+class TestProxyStateIntegration:
+    def test_state_path_none_disables_persistence(self, tmp_path):
+        # Default path: no persistence. _persist() is a no-op even if called.
+        state = ProxyState(state_path=None)
+        state.api_key = "act_xyz"
+        state._persist()
+        # No file should have been created at the default path either.
+        # (We can't easily assert on that from the test, but the no-op
+        # contract is what we're checking — no exception.)
+
+    def test_state_path_set_persists_api_key(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = ProxyState(state_path=path)
+        state.api_key = "act_persist"
+        state.connected_account = {"email": "u@example.com"}
+        state._persist()
+        on_disk = json.loads(path.read_text())
+        assert on_disk["api_key"] == "act_persist"
+        assert on_disk["connected_account"]["email"] == "u@example.com"
+
+    def test_init_loads_persisted_api_key(self, tmp_path):
+        path = tmp_path / "state.json"
+        save_persisted_state(
+            path,
+            {
+                "api_key": "act_from_disk",
+                "connected_account": {"email": "loaded@example.com"},
+                "target_base_url": "https://restored.example.com",
+                "safety_enabled": False,
+            },
+        )
+        state = ProxyState(state_path=path)
+        assert state.api_key == "act_from_disk"
+        assert state.connected_account == {"email": "loaded@example.com"}
+        assert state.target_base_url == "https://restored.example.com"
+        assert state.safety_enabled is False
+
+    def test_persisted_state_overrides_env_seed(self, tmp_path, monkeypatch):
+        # Even if the env supplies a key, a persisted key wins — that's the
+        # whole point of "this dashboard-set key survives restart".
+        monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+        path = tmp_path / "state.json"
+        save_persisted_state(path, {"api_key": "act_dashboard"})
+        state = ProxyState(state_path=path)
+        assert state.api_key == "act_dashboard"
+
+    def test_init_with_corrupt_file_falls_back_cleanly(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+        path = tmp_path / "state.json"
+        path.write_text("not json {{{")
+        # Should not raise; should fall back to env-seeded api_key.
+        state = ProxyState(state_path=path)
+        assert state.api_key == "env-key"
+
+    def test_target_base_url_strips_trailing_slash(self, tmp_path):
+        path = tmp_path / "state.json"
+        save_persisted_state(path, {"target_base_url": "https://x.com/api/"})
+        state = ProxyState(state_path=path)
+        assert state.target_base_url == "https://x.com/api"


### PR DESCRIPTION
## Summary

- New \`src/aceteam_aep/proxy/state_persistence.py\`: opt-in JSON file (default \`~/.aceteam-aep/state.json\`, mode 0600) that mirrors a small slice of \`ProxyState\`
- Persisted: \`api_key\`, \`connected_account\`, \`target_base_url\`, \`safety_enabled\`
- Wired into \`ProxyState.__init__\` (load) and four mutation handlers in \`proxy/app.py\` (save)
- 18 new tests in \`tests/test_state_persistence.py\` covering load/save/atomic-write/permissions/restart behavior

## Why

Every container restart wiped the dashboard-set \`api_key\` (including \`act_*\` keys from the AceTeam connect flow), the connected account metadata, the target base URL override, and the safety toggle. Users had to reconnect from scratch each time. That's the real "dies on restart" pain from #10.

The bigger \"history / analytics\" piece of #10 is already shipped — the existing \`EventStore\` (aiosqlite-backed) holds calls, signals, decisions. Duplicating that here would just create two sources of truth, so this PR scopes to the control-plane slice that the EventStore doesn't cover.

## What's NOT in scope (deferred)

- Supabase/Postgres backend for the EventStore — that's #16 (platform integration), where the schema already exists as \`execution_envelopes\`
- ClickHouse — speculative, no caller yet
- Persisting enforcement policy / budget / custom policies — those have other source-of-truth (yaml files, CRUD store), persisting here would shadow them
- Per-entity isolation — that's #11 (depends on this landing first)

## Behavior change matrix

| Before | After |
|---|---|
| api_key wiped on restart | Survives if persisted before |
| connected_account wiped | Survives |
| target_base_url override wiped | Survives |
| safety toggle reset to True | Last toggle state preserved |
| Fresh \`pip install\` user | Same as before — persistence stays disabled until \`AEP_STATE_PATH\` is set or default file exists |

## Test plan

- [x] 18 unit tests pass (load/save/roundtrip/atomic/0o600/corrupt-fallback/env-override)
- [x] Existing proxy + safety + custom-policies tests still pass (47 of them, 1 pre-existing failure deselected)
- [x] \`uv run ruff check\` clean on new files (the 6 errors in proxy/app.py are pre-existing E501s, unrelated)
- [ ] Manual: set api_key via dashboard → restart proxy → confirm key restored

Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)