### PR TITLE
feat(proxy): per-entity ProxyStateManager — opt-in multi-tenant Phase A

### DIFF
--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -43,6 +43,12 @@ from .logutil import configure_proxy_debug_logging
 from .openclaw_sync import get_configured_path as _openclaw_config_path
 from .openclaw_sync import refresh_openclaw_config
 from .redis_publisher import build_event, publish_event
+from .state_manager import (
+    ProxyStateManager,
+    get_max_entities,
+    is_multi_tenant_enabled,
+    per_entity_state_path,
+)
 from .state_persistence import (
     get_configured_path as _state_persistence_path,
 )
@@ -402,6 +408,8 @@ def create_proxy_app(
 ) -> Starlette:
     """Create the AEP proxy ASGI app."""
 
+    base_state_path = _state_persistence_path()
+
     state = ProxyState(
         target_base_url=target_base_url,
         detectors=detectors,
@@ -409,7 +417,31 @@ def create_proxy_app(
         budget=budget,
         budget_per_session=budget_per_session,
         event_store=event_store,
-        state_path=_state_persistence_path(),
+        state_path=base_state_path,
+    )
+
+    # Multi-tenant manager — opt-in via AEP_MULTI_TENANT=1. When the env flag
+    # is unset (the default), the manager always returns the singleton ``state``
+    # so existing single-tenant deployments and tests are unaffected. When
+    # enabled, requests with ``X-AEP-Entity`` (or distinct ``Authorization``
+    # bearer keys) get isolated ``ProxyState`` buckets, capped at
+    # ``AEP_MAX_ENTITIES`` (default 64) with LRU eviction.
+    def _entity_state_factory(entity_id: str) -> ProxyState:
+        return ProxyState(
+            target_base_url=target_base_url,
+            detectors=detectors,
+            policy=policy,
+            budget=budget,
+            budget_per_session=budget_per_session,
+            event_store=event_store,
+            state_path=per_entity_state_path(base_state_path, entity_id),
+        )
+
+    state_manager = ProxyStateManager(
+        multi_tenant=is_multi_tenant_enabled(),
+        max_entities=get_max_entities(),
+        default=state,
+        factory=_entity_state_factory,
     )
 
     # Enable debug logging if requested (see logutil; uvicorn/defaults drop DEBUG)
@@ -444,6 +476,11 @@ def create_proxy_app(
 
     async def proxy_handler(request: Request) -> Response:
         """Forward request to target API with safety interception."""
+        # Resolve per-request state at the very top so any deferred work
+        # (streaming on-complete callbacks, asyncio.ensure_future events)
+        # captures *this* request's state via closure rather than re-resolving
+        # later when the contextual entity may differ.
+        state = state_manager.get_for_request(request)
         call_id = uuid.uuid4().hex[:8]
         path = request.url.path
         body_bytes = await request.body()
@@ -1059,6 +1096,7 @@ def create_proxy_app(
 
         GET returns current state. POST accepts {"enabled": bool} and/or {"policy": dict}.
         """
+        state = state_manager.get_for_request(request)
         if request.method == "GET":
             return Response(
                 json.dumps(
@@ -1137,6 +1175,7 @@ def create_proxy_app(
 
     # Custom policies CRUD (collection + item routes below).
     async def custom_policies_collection_handler(request: Request) -> Response:
+        state = state_manager.get_for_request(request)
         if request.method == "GET":
             policies = [p.model_dump() for p in state.custom_policy_store.all()]
             return Response(
@@ -1161,6 +1200,7 @@ def create_proxy_app(
         )
 
     async def custom_policy_item_handler(request: Request) -> Response:
+        state = state_manager.get_for_request(request)
         raw_id = request.path_params["policy_id"]
         policy_id = _normalize_policy_id(raw_id)
         if policy_id is None:
@@ -1206,7 +1246,7 @@ def create_proxy_app(
     # then renders "Connected as <email>" instead of the cryptic prefix.
     # No-op for BYOK keys (sk-/sk-ant-) since OpenAI/Anthropic don't expose
     # a comparable identity endpoint and we have no way to look up identity.
-    async def _refresh_connected_account() -> None:
+    async def _refresh_connected_account(state: ProxyState = state) -> None:
         key = state.api_key
         if not key or not key.startswith("act_"):
             return
@@ -1247,6 +1287,8 @@ def create_proxy_app(
     # The raw key is only held in process memory (never written to disk) and is used
     # as the fallback Authorization header when a /v1/* request arrives without one.
     async def api_key_handler(request: Request) -> Response:
+        state = state_manager.get_for_request(request)
+
         def _classify(key: str) -> str:
             # Surface where the key came from so the dashboard can show
             # "Connected to AceTeam" instead of the cryptic "KEY: act_bb3..."
@@ -1344,7 +1386,7 @@ def create_proxy_app(
         # If the caller didn't pre-supply identity, try fetching it from the
         # upstream gateway. Skip for non-act_* keys inside _refresh_*.
         if state.connected_account is None:
-            await _refresh_connected_account()
+            await _refresh_connected_account(state)
         # Auto-sync the OpenClaw catalog from the AceTeam gateway whenever a
         # fresh act_* key lands. Opt-in via env: when AEP_OPENCLAW_CONFIG_PATH
         # is set (i.e., compose mounts the openclaw config dir into the proxy),
@@ -1368,6 +1410,7 @@ def create_proxy_app(
     # agent. Mirrors programasweights.com/browser but against policies that
     # already live in this process.
     async def policy_test_handler(request: Request) -> Response:
+        state = state_manager.get_for_request(request)
         body, json_err = await _read_json_body(request)
         if json_err is not None:
             return json_err
@@ -1426,6 +1469,7 @@ def create_proxy_app(
     async def routing_handler(request: Request) -> Response:
         if request.method != "GET":
             return JSONResponse({"error": "GET only"}, status_code=405)
+        state = state_manager.get_for_request(request)
 
         # Layer 1: this proxy. Always present. List the active detectors and
         # the count of enabled custom policies so the user can see what

--- a/src/aceteam_aep/proxy/state_manager.py
+++ b/src/aceteam_aep/proxy/state_manager.py
@@ -1,0 +1,227 @@
+"""Per-entity ``ProxyState`` partitioning for multi-tenant proxy deployments.
+
+The proxy historically used a single global ``ProxyState`` shared by every
+request. That works for an individual developer running ``aceteam-aep proxy``
+on their laptop, but breaks down when the same gateway fronts traffic for
+multiple orgs / agents — they'd see each other's signals, costs, and
+connected-account metadata.
+
+This module adds opt-in per-entity isolation. Default is unchanged: the
+manager hands every request the same ``ProxyState`` (the singleton path),
+so a fresh ``pip install`` user experiences zero behavioral diff.
+
+Enable by setting ``AEP_MULTI_TENANT=1``. The manager extracts an
+``entity_id`` per request:
+
+1. ``X-AEP-Entity`` request header (preferred; matches the existing AEP
+   header conventions in :mod:`.headers`)
+2. Fallback: a stable shard derived from the ``Authorization`` header so
+   that even agents that don't yet emit ``X-AEP-Entity`` get isolated by
+   API key
+3. Last resort: ``"default"`` — used for the dashboard / setup / health
+   endpoints where there's no agent context
+
+Entities are stored in an LRU dict capped at ``AEP_MAX_ENTITIES`` (default
+64) so a buggy caller that emits a fresh entity per request can't OOM the
+proxy. Eviction is benign — the next request from that entity rebuilds a
+fresh ``ProxyState`` (with persistence loading whatever was last saved).
+
+Why explicit handler lookup rather than a contextvar:
+
+The streaming on-complete callback fires *after* the request scope ends —
+contextvar resolution would return whatever entity is "current" at the
+time the callback runs, not the entity the request belonged to. Each
+handler explicitly calls ``manager.get_for_request(request)`` at the top
+so the per-request state is captured by closure before any deferred work
+is scheduled.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from starlette.requests import Request
+
+    from .app import ProxyState
+
+log = logging.getLogger(__name__)
+
+MULTI_TENANT_ENV = "AEP_MULTI_TENANT"
+MAX_ENTITIES_ENV = "AEP_MAX_ENTITIES"
+ENTITY_HEADER = "x-aep-entity"
+
+_DEFAULT_MAX_ENTITIES = 64
+
+# Filesystem-safe sanitizer for per-entity state file paths. We want a
+# round-trippable shape but slugify aggressively — the original entity_id
+# stays in the file's contents, so loss in the filename is acceptable.
+_FILENAME_SAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def is_multi_tenant_enabled() -> bool:
+    """Read the env flag. Default off for back-compat with single-tenant deploys."""
+    raw = os.environ.get(MULTI_TENANT_ENV, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def get_max_entities() -> int:
+    """Read the LRU cap; clamp to a sane minimum so a misconfigured value can't pin to 0."""
+    raw = os.environ.get(MAX_ENTITIES_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_ENTITIES
+    try:
+        n = int(raw)
+    except ValueError:
+        log.warning(
+            "ignoring non-integer %s=%r; using %d",
+            MAX_ENTITIES_ENV,
+            raw,
+            _DEFAULT_MAX_ENTITIES,
+        )
+        return _DEFAULT_MAX_ENTITIES
+    return max(1, n)
+
+
+def entity_for_request(request: Request) -> str:
+    """Derive a stable entity id from a request.
+
+    Order of preference:
+
+    1. Explicit ``X-AEP-Entity`` header — the canonical way for agents to
+       declare which org/tenant they belong to.
+    2. ``Authorization: Bearer <key>`` prefix — uses the first 12 chars of
+       the key after stripping whitespace. Two requests from the same key
+       always shard to the same entity even without the header.
+    3. ``"default"`` — the singleton bucket. Used by the dashboard,
+       healthz, setup wizard, and anything else where there's no agent
+       context.
+
+    Returning ``"default"`` is also what's returned in non-multi-tenant
+    mode (the manager will simply ignore the value), so this function is
+    safe to call unconditionally.
+    """
+    header = request.headers.get(ENTITY_HEADER, "").strip()
+    if header:
+        return header
+    auth = request.headers.get("authorization", "").strip()
+    if auth.lower().startswith("bearer "):
+        key = auth[7:].strip()
+        if key:
+            # Prefix is enough to keep distinct keys distinct without
+            # putting full secrets into in-memory dict keys / log lines.
+            return f"key:{key[:12]}"
+    return "default"
+
+
+def per_entity_state_path(base_path: Path | None, entity_id: str) -> Path | None:
+    """Return ``base_path``'s sibling ``states/<sanitized>.json``, or None.
+
+    The default singleton entity ("default") keeps writing to the original
+    ``base_path`` so that turning multi-tenant on/off doesn't accidentally
+    orphan the previously-persisted state. Only non-default entities get
+    their own per-entity state file under a ``states/`` subdir next to
+    the configured base path.
+    """
+    if base_path is None:
+        return None
+    if entity_id == "default":
+        return base_path
+    sanitized = _FILENAME_SAFE.sub("_", entity_id)
+    # Collapse runs of dots so a "../../" entity_id can't survive as ".._.._".
+    # We aggressively replace any "." with "_" once we've hit the safe-chars
+    # filter — dots in filenames are fine, but path-traversal-shaped sequences
+    # are too easy to mis-handle so we just disallow the character outright.
+    sanitized = sanitized.replace(".", "_")
+    sanitized = sanitized[:64].strip("_") or "entity"
+    return base_path.parent / "states" / f"{sanitized}.json"
+
+
+class ProxyStateManager:
+    """Per-entity ``ProxyState`` registry with LRU eviction.
+
+    In single-tenant mode (``multi_tenant=False``) every lookup returns the
+    same ``default`` state — the manager is a no-op pass-through. Tests and
+    existing single-tenant deployments are unaffected.
+
+    In multi-tenant mode the manager creates a fresh ``ProxyState`` per
+    distinct entity_id via the ``factory`` callable, capping the in-memory
+    dict at ``max_entities`` (LRU evicts the least-recently-used bucket
+    when the cap is hit).
+    """
+
+    def __init__(
+        self,
+        *,
+        multi_tenant: bool,
+        max_entities: int,
+        default: ProxyState,
+        factory: Callable[[str], ProxyState],
+    ) -> None:
+        self._multi_tenant = multi_tenant
+        self._max_entities = max_entities
+        self._factory = factory
+        # OrderedDict gives us O(1) LRU via move_to_end + popitem(last=False).
+        # The "default" entity is always present so single-tenant lookups
+        # are a single dict get.
+        self._states: OrderedDict[str, ProxyState] = OrderedDict()
+        self._states["default"] = default
+
+    @property
+    def multi_tenant(self) -> bool:
+        return self._multi_tenant
+
+    def get_for_entity(self, entity_id: str) -> ProxyState:
+        """Return the ``ProxyState`` for ``entity_id``; create + evict as needed.
+
+        Always returns the singleton when multi-tenant is disabled, so
+        single-tenant callers can ignore ``entity_id`` entirely.
+        """
+        if not self._multi_tenant:
+            return self._states["default"]
+        if entity_id in self._states:
+            self._states.move_to_end(entity_id)
+            return self._states[entity_id]
+        # Cap reached → evict LRU before adding the new one. "default" is
+        # protected from eviction since it's the bucket every non-tenant
+        # request lands in (and where dashboard/health endpoints look).
+        while len(self._states) >= self._max_entities:
+            evicted_id, _ = next(
+                ((k, v) for k, v in self._states.items() if k != "default"), (None, None)
+            )
+            if evicted_id is None:
+                # max_entities=1 with multi-tenant on — degenerate config,
+                # but don't crash; just don't create a new bucket.
+                return self._states["default"]
+            self._states.pop(evicted_id)
+            log.info("multi-tenant LRU evicted entity_id=%r", evicted_id)
+        new_state = self._factory(entity_id)
+        self._states[entity_id] = new_state
+        return new_state
+
+    def get_for_request(self, request: Request) -> ProxyState:
+        """Convenience: derive entity_id from the request and look up state."""
+        return self.get_for_entity(entity_for_request(request))
+
+    def all_entities(self) -> list[str]:
+        """List currently-resident entity ids; for dashboard introspection."""
+        return list(self._states.keys())
+
+
+__all__ = [
+    "ENTITY_HEADER",
+    "MAX_ENTITIES_ENV",
+    "MULTI_TENANT_ENV",
+    "ProxyStateManager",
+    "entity_for_request",
+    "get_max_entities",
+    "is_multi_tenant_enabled",
+    "per_entity_state_path",
+]

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,302 @@
+"""Tests for the per-entity ProxyStateManager (multi-tenant proxy support)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aceteam_aep.proxy.app import ProxyState
+from aceteam_aep.proxy.state_manager import (
+    ENTITY_HEADER,
+    MAX_ENTITIES_ENV,
+    MULTI_TENANT_ENV,
+    ProxyStateManager,
+    entity_for_request,
+    get_max_entities,
+    is_multi_tenant_enabled,
+    per_entity_state_path,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(MULTI_TENANT_ENV, raising=False)
+    monkeypatch.delenv(MAX_ENTITIES_ENV, raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+
+
+def _request_with_headers(**headers) -> MagicMock:
+    """Build a minimal request stand-in with case-insensitive header lookup."""
+    req = MagicMock()
+    # Starlette's request.headers is case-insensitive; mirror that.
+    norm = {k.lower(): v for k, v in headers.items()}
+    req.headers = MagicMock()
+    req.headers.get = lambda name, default="": norm.get(name.lower(), default)
+    return req
+
+
+class TestIsMultiTenantEnabled:
+    def test_unset_returns_false(self):
+        assert is_multi_tenant_enabled() is False
+
+    @pytest.mark.parametrize("v", ["1", "true", "TRUE", "yes", "on", "True"])
+    def test_truthy_values(self, v, monkeypatch):
+        monkeypatch.setenv(MULTI_TENANT_ENV, v)
+        assert is_multi_tenant_enabled() is True
+
+    @pytest.mark.parametrize("v", ["0", "false", "no", "off", "garbage", ""])
+    def test_falsy_values(self, v, monkeypatch):
+        monkeypatch.setenv(MULTI_TENANT_ENV, v)
+        assert is_multi_tenant_enabled() is False
+
+
+class TestGetMaxEntities:
+    def test_unset_returns_default(self):
+        assert get_max_entities() == 64
+
+    def test_explicit_value(self, monkeypatch):
+        monkeypatch.setenv(MAX_ENTITIES_ENV, "10")
+        assert get_max_entities() == 10
+
+    def test_invalid_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(MAX_ENTITIES_ENV, "not-a-number")
+        assert get_max_entities() == 64
+
+    def test_zero_clamped_to_one(self, monkeypatch):
+        monkeypatch.setenv(MAX_ENTITIES_ENV, "0")
+        assert get_max_entities() == 1
+
+
+class TestEntityForRequest:
+    def test_explicit_header_wins(self):
+        req = _request_with_headers(**{
+            ENTITY_HEADER: "org:acme",
+            "Authorization": "Bearer act_someothertoken",
+        })
+        assert entity_for_request(req) == "org:acme"
+
+    def test_header_is_stripped(self):
+        req = _request_with_headers(**{ENTITY_HEADER: "  org:acme  "})
+        assert entity_for_request(req) == "org:acme"
+
+    def test_falls_back_to_authorization_prefix(self):
+        req = _request_with_headers(Authorization="Bearer act_8b3abc123def4567")
+        assert entity_for_request(req) == "key:act_8b3abc12"
+
+    def test_authorization_lowercase_bearer_is_accepted(self):
+        # HTTP scheme matching is case-insensitive.
+        req = _request_with_headers(Authorization="bearer act_xyz_long_enough")
+        assert entity_for_request(req) == "key:act_xyz_long"
+
+    def test_missing_header_returns_default(self):
+        req = _request_with_headers()
+        assert entity_for_request(req) == "default"
+
+    def test_authorization_without_bearer_returns_default(self):
+        req = _request_with_headers(Authorization="Basic foobar")
+        assert entity_for_request(req) == "default"
+
+    def test_empty_bearer_returns_default(self):
+        req = _request_with_headers(Authorization="Bearer ")
+        assert entity_for_request(req) == "default"
+
+
+class TestPerEntityStatePath:
+    def test_none_base_path_returns_none(self):
+        assert per_entity_state_path(None, "any") is None
+
+    def test_default_entity_returns_base_path(self, tmp_path):
+        base = tmp_path / "state.json"
+        assert per_entity_state_path(base, "default") == base
+
+    def test_non_default_lands_in_states_subdir(self, tmp_path):
+        base = tmp_path / "state.json"
+        result = per_entity_state_path(base, "org:acme")
+        assert result is not None
+        assert result.parent == tmp_path / "states"
+        assert result.name == "org_acme.json"
+
+    def test_unsafe_chars_sanitized(self, tmp_path):
+        base = tmp_path / "state.json"
+        result = per_entity_state_path(base, "../../etc/passwd")
+        assert result is not None
+        # "/" and "." (when leading) are scrubbed to underscores; the path
+        # MUST still land inside the states/ subdir.
+        assert result.parent == tmp_path / "states"
+        assert ".." not in result.name
+
+
+class TestProxyStateManagerSingleTenant:
+    def test_singleton_mode_always_returns_default(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=False,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        assert manager.get_for_entity("org:a") is default
+        assert manager.get_for_entity("org:b") is default
+        assert manager.get_for_entity("default") is default
+
+    def test_singleton_factory_never_called(self):
+        default = ProxyState()
+        factory_calls = []
+        manager = ProxyStateManager(
+            multi_tenant=False,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: factory_calls.append(eid) or ProxyState(),
+        )
+        manager.get_for_entity("a")
+        manager.get_for_entity("b")
+        assert factory_calls == []
+
+
+class TestProxyStateManagerMultiTenant:
+    def test_distinct_entities_get_distinct_states(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        a = manager.get_for_entity("org:a")
+        b = manager.get_for_entity("org:b")
+        assert a is not b
+        assert a is not default
+
+    def test_same_entity_returns_same_state(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        first = manager.get_for_entity("org:a")
+        second = manager.get_for_entity("org:a")
+        assert first is second
+
+    def test_default_entity_returns_default_state(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        assert manager.get_for_entity("default") is default
+
+    def test_lru_evicts_oldest_when_cap_hit(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=3,  # default + 2 entities = full
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        a = manager.get_for_entity("a")
+        b = manager.get_for_entity("b")
+        # Cap hit when we ask for c — a is the oldest non-default, evicted.
+        c = manager.get_for_entity("c")
+        # b and c still resident (and default of course).
+        assert manager.get_for_entity("b") is b
+        assert manager.get_for_entity("c") is c
+        # Asking for "a" again creates a fresh state — old `a` is gone.
+        a2 = manager.get_for_entity("a")
+        assert a2 is not a
+
+    def test_default_protected_from_eviction(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=2,  # default + 1 entity
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        manager.get_for_entity("a")
+        manager.get_for_entity("b")  # would evict — but default must survive
+        manager.get_for_entity("c")
+        assert manager.get_for_entity("default") is default
+
+    def test_recently_accessed_not_evicted(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=3,
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        a = manager.get_for_entity("a")
+        manager.get_for_entity("b")
+        # Re-access a (move to end of LRU)
+        manager.get_for_entity("a")
+        # Add c — b should be evicted (older), not a.
+        manager.get_for_entity("c")
+        assert manager.get_for_entity("a") is a
+
+    def test_get_for_request_uses_header(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        req_a = _request_with_headers(**{ENTITY_HEADER: "tenant_a"})
+        req_b = _request_with_headers(**{ENTITY_HEADER: "tenant_b"})
+        a = manager.get_for_request(req_a)
+        b = manager.get_for_request(req_b)
+        assert a is not b
+        assert manager.get_for_request(req_a) is a
+
+    def test_factory_receives_entity_id(self):
+        default = ProxyState()
+        seen = []
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: seen.append(eid) or ProxyState(),
+        )
+        manager.get_for_entity("org:acme")
+        manager.get_for_entity("org:beta")
+        assert seen == ["org:acme", "org:beta"]
+
+    def test_all_entities_lists_resident(self):
+        default = ProxyState()
+        manager = ProxyStateManager(
+            multi_tenant=True,
+            max_entities=64,
+            default=default,
+            factory=lambda eid: ProxyState(),
+        )
+        manager.get_for_entity("a")
+        manager.get_for_entity("b")
+        assert sorted(manager.all_entities()) == ["a", "b", "default"]
+
+
+class TestPerEntityPersistence:
+    def test_each_entity_gets_own_state_file(self, tmp_path):
+        base = tmp_path / "state.json"
+        path_a = per_entity_state_path(base, "org:a")
+        path_b = per_entity_state_path(base, "org:b")
+        assert path_a != path_b
+
+        state_a = ProxyState(state_path=path_a)
+        state_b = ProxyState(state_path=path_b)
+        state_a.api_key = "key_for_a"
+        state_b.api_key = "key_for_b"
+        state_a._persist()
+        state_b._persist()
+
+        # Each entity reads back its own key.
+        restored_a = ProxyState(state_path=path_a)
+        restored_b = ProxyState(state_path=path_b)
+        assert restored_a.api_key == "key_for_a"
+        assert restored_b.api_key == "key_for_b"


### PR DESCRIPTION
## Summary

- New \`src/aceteam_aep/proxy/state_manager.py\` — \`ProxyStateManager\` with LRU eviction, entity extraction, env-flag opt-in
- Refactors 7 handlers in \`proxy/app.py\` to call \`state_manager.get_for_request(request)\` at the top so per-entity state is captured by closure before any deferred work runs
- 40 new tests in \`tests/test_state_manager.py\`
- **Stacked on #111** (state persistence) — each entity gets its own state file under \`~/.aceteam-aep/states/<sanitized>.json\`

## Why this approach (option B over A)

The Explore agent's [scope analysis](https://github.com/aceteam-ai/aceteam-aep/issues/11#issuecomment-4376074731) flagged that a contextvar approach would break the streaming on-complete callback — that fires *after* the request scope ends, so contextvar resolution would return whatever entity is "current" at the time the callback runs, not the request's entity.

Explicit handler lookup is mechanical (one line at the top of each mutating handler) but robust to any deferred work pattern.

## Default behavior unchanged

\`AEP_MULTI_TENANT\` unset → manager returns the same singleton for every \`get_for_entity()\` / \`get_for_request()\` call. The factory closure isn't invoked. Existing single-tenant deployments, tests, and behavior are byte-identical.

## When AEP_MULTI_TENANT=1

- \`X-AEP-Entity\` header → fallback to bearer-key prefix (\`key:<first-12-chars>\`) → \`"default"\`
- LRU dict capped at \`AEP_MAX_ENTITIES\` (default 64)
- \`"default"\` entity protected from eviction (it's where dashboard/health endpoints land)
- Per-entity state files mirror the \`base_state_path\` parent (\`~/.aceteam-aep/states/<sanitized>.json\`)

## Phase B (deferred to follow-up PRs)

- Dashboard filtering by entity — currently \`/dashboard/api/state\` shows the default entity's view
- EventStore queries scoped by entity_id — needs #16 platform integration to know what schema lands there
- Per-entity custom policy stores — currently shared because the dashboard's CRUD writes to the singleton

## Test plan

- [x] 40 new unit tests pass (entity extraction / LRU / per-entity persistence / single-tenant pass-through / env parsing)
- [x] 107 existing proxy + safety + custom-policies + persistence tests still pass (2 pre-existing failures deselected, unrelated to this PR)
- [x] \`uv run ruff check\` clean on new files
- [ ] Manual: with \`AEP_MULTI_TENANT=1\`, confirm two requests with different \`X-AEP-Entity\` headers see distinct \`signals\` / \`cost\` accumulation
- [ ] Manual: confirm LRU eviction at \`AEP_MAX_ENTITIES=3\`

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)