### PR TITLE
fix(providers): raise on silent Anthropic stream rejections

### DIFF
--- a/src/aceteam_aep/__init__.py
+++ b/src/aceteam_aep/__init__.py
@@ -26,6 +26,7 @@ from .models import MODEL_REGISTRY, ModelInfo, detect_provider, get_model_info
 from .pricing import DefaultPricingProvider, PricingProvider
 from .prompt import wrap_context, wrap_examples, wrap_file, wrap_xml
 from .protocols import HasCitations, UsageCollector
+from .providers import ProviderResponseError
 from .spans import Span, SpanTracker
 from .stream import StreamEvent
 from .structured import structured_output
@@ -85,6 +86,8 @@ __all__ = [
     # Pricing
     "DefaultPricingProvider",
     "PricingProvider",
+    # Providers
+    "ProviderResponseError",
     # Embeddings
     "CohereEmbeddings",
     "EmbeddingClient",

--- a/src/aceteam_aep/agent.py
+++ b/src/aceteam_aep/agent.py
@@ -251,24 +251,38 @@ async def run_agent_loop_stream(
             accumulated_tool_calls = []
             call_usage = Usage()
 
-            async for stream_chunk in client.chat_stream(
-                working,
-                tools=tool_schemas,
-                temperature=temperature,
-                max_tokens=max_tokens,
-            ):
-                if stream_chunk.delta_text:
-                    accumulated_text += stream_chunk.delta_text
-                    yield chunk_event(stream_chunk.delta_text)
+            # If chat_stream raises (e.g. ProviderResponseError on a
+            # silent upstream rejection), the budget reservation and the
+            # llm_span would otherwise be leaked — they're settled/ended
+            # only on the success path below. Close them out here before
+            # the exception propagates, so callers with budget/span
+            # trackers don't accumulate stuck reservations.
+            try:
+                async for stream_chunk in client.chat_stream(
+                    working,
+                    tools=tool_schemas,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                ):
+                    if stream_chunk.delta_text:
+                        accumulated_text += stream_chunk.delta_text
+                        yield chunk_event(stream_chunk.delta_text)
 
-                if stream_chunk.delta_tool_calls:
-                    accumulated_tool_calls.extend(stream_chunk.delta_tool_calls)
+                    if stream_chunk.delta_tool_calls:
+                        accumulated_tool_calls.extend(stream_chunk.delta_tool_calls)
 
-                if stream_chunk.usage:
-                    call_usage = stream_chunk.usage
+                    if stream_chunk.usage:
+                        call_usage = stream_chunk.usage
 
-                if stream_chunk.finish_reason:
-                    last_finish_reason = stream_chunk.finish_reason
+                    if stream_chunk.finish_reason:
+                        last_finish_reason = stream_chunk.finish_reason
+            except Exception:
+                if llm_span and span_tracker:
+                    span_tracker.end_span(llm_span.span_id, status="ERROR")
+                    yield span_end_event(llm_span.span_id, status="ERROR")
+                if budget and reservation:
+                    budget.settle(reservation, Decimal("0"))
+                raise
 
             total_usage = total_usage + call_usage
 
@@ -321,9 +335,7 @@ async def run_agent_loop_stream(
                         ),
                     )
                 )
-                yield chunk_event(
-                    "[Retrying -- previous response exceeded token limit]\n\n"
-                )
+                yield chunk_event("[Retrying -- previous response exceeded token limit]\n\n")
                 last_finish_reason = None
                 continue
 

--- a/src/aceteam_aep/providers/__init__.py
+++ b/src/aceteam_aep/providers/__init__.py
@@ -1,7 +1,13 @@
 """LLM provider implementations."""
 
 from .anthropic import AnthropicClient
+from .errors import ProviderResponseError
 from .google import GoogleClient
 from .openai import OpenAIClient
 
-__all__ = ["AnthropicClient", "GoogleClient", "OpenAIClient"]
+__all__ = [
+    "AnthropicClient",
+    "GoogleClient",
+    "OpenAIClient",
+    "ProviderResponseError",
+]

--- a/src/aceteam_aep/providers/anthropic.py
+++ b/src/aceteam_aep/providers/anthropic.py
@@ -9,6 +9,7 @@ from typing import Any
 import anthropic
 
 from ..types import ChatMessage, ChatResponse, StreamChunk, ToolCallRequest, Usage
+from .errors import ProviderResponseError
 
 
 def _extract_json_schema(response_format: dict[str, Any]) -> dict[str, Any] | None:
@@ -232,6 +233,13 @@ class AnthropicClient:
             current_tool: dict[str, Any] | None = None
             input_tokens = 0
             output_tokens = 0
+            # Tracks whether the stream produced anything callers can use.
+            # If a stream closes with all of these still false, the upstream
+            # request was silently rejected (e.g., a revoked BYOK key) and
+            # we raise instead of letting callers render a blank reply.
+            produced_text = False
+            produced_tool_call = False
+            produced_finish = False
 
             async for event in stream:
                 if event.type == "message_start":
@@ -251,6 +259,7 @@ class AnthropicClient:
 
                 elif event.type == "content_block_delta":
                     if hasattr(event.delta, "text"):
+                        produced_text = True
                         yield StreamChunk(delta_text=event.delta.text)
                     elif hasattr(event.delta, "partial_json") and current_tool:
                         current_tool["arguments"] += event.delta.partial_json
@@ -262,6 +271,7 @@ class AnthropicClient:
                             args = json.loads(raw_args) if raw_args.strip() else {}
                         except (json.JSONDecodeError, TypeError):
                             args = {"raw": current_tool["arguments"]}
+                        produced_tool_call = True
                         yield StreamChunk(
                             delta_tool_calls=[
                                 ToolCallRequest(
@@ -278,6 +288,7 @@ class AnthropicClient:
                         output_tokens = event.usage.output_tokens
                     finish = getattr(event.delta, "stop_reason", None)
                     if finish:
+                        produced_finish = True
                         # Flush any in-progress tool call that was truncated
                         # (e.g. by max_tokens). Anthropic skips content_block_stop
                         # when the response is cut short, so the accumulated
@@ -306,6 +317,18 @@ class AnthropicClient:
                                 total_tokens=input_tokens + output_tokens,
                             ),
                         )
+
+        if not (produced_text or produced_tool_call or produced_finish):
+            # Anthropic accepted the request, opened the SSE stream, then
+            # closed it without emitting a single text, tool-call, or
+            # stop-reason event. Observed in production from a revoked
+            # BYOK key where the upstream rejection arrives as a soft
+            # close rather than an exception. Raise so callers can
+            # surface a real error instead of an empty assistant reply.
+            raise ProviderResponseError(
+                f"Anthropic stream closed with no content for model {self._model!r}",
+                provider="anthropic",
+            )
 
 
 __all__ = ["AnthropicClient"]

--- a/src/aceteam_aep/providers/errors.py
+++ b/src/aceteam_aep/providers/errors.py
@@ -1,0 +1,40 @@
+"""Typed exceptions raised by provider clients."""
+
+from __future__ import annotations
+
+
+class ProviderResponseError(Exception):
+    """Raised when an LLM provider returns a structurally-valid response
+    that conveys no usable content.
+
+    The most common trigger is an upstream silent rejection: the provider
+    accepts the request, opens an SSE stream, then closes it without
+    emitting any text, tool call, or finish-reason events. Without an
+    explicit raise here, callers see a successful-looking empty stream
+    and surface it to end-users as a blank assistant reply.
+
+    Attributes:
+        provider: Short slug of the provider that produced the response
+            (e.g., ``"anthropic"``, ``"openai"``). Used by callers to
+            map to user-facing copy without re-parsing the message.
+        user_message: Short, end-user-safe sentence. Callers may
+            surface this verbatim or override it.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str,
+        user_message: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.user_message = user_message or (
+            "The model returned an empty response. This usually means the "
+            "request was rejected upstream — check your API key permissions "
+            "and the selected model."
+        )
+
+
+__all__ = ["ProviderResponseError"]

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,10 +1,13 @@
 """Tests for agent loop with mock provider."""
 
+from collections.abc import AsyncIterator
+
 import pytest
 
 from aceteam_aep.agent import run_agent_loop, run_agent_loop_stream
 from aceteam_aep.budget import BudgetEnforcer
 from aceteam_aep.costs import CostTracker
+from aceteam_aep.providers.errors import ProviderResponseError
 from aceteam_aep.spans import SpanTracker
 from aceteam_aep.tools import tool
 from aceteam_aep.types import ChatMessage, ChatResponse, StreamChunk, ToolCallRequest, Usage
@@ -320,3 +323,78 @@ async def test_max_iterations():
 
     # Should have stopped after 3 iterations
     assert client._call_count == 3
+
+
+class _RaisingStreamClient:
+    """ChatClient whose chat_stream raises before yielding any chunks.
+
+    Mirrors the shape of a real silent-rejection: chat_stream is an
+    async generator that, on first iteration, raises an exception.
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    @property
+    def model_name(self) -> str:
+        return "mock-raising"
+
+    async def chat(self, messages, **kwargs):  # pragma: no cover - unused
+        raise self._exc
+
+    async def chat_stream(self, messages, **kwargs) -> AsyncIterator[StreamChunk]:
+        raise self._exc
+        yield  # pragma: no cover - unreachable, marks this as an async gen
+
+
+@pytest.mark.asyncio
+async def test_stream_releases_reservation_on_provider_error():
+    """run_agent_loop_stream must settle the budget reservation when
+    chat_stream raises, otherwise the reserved amount stays held and
+    eventually starves the budget for subsequent calls.
+
+    Regression guard for the ProviderResponseError cleanup path
+    introduced in aceteam-aep#115.
+    """
+    client = _RaisingStreamClient(ProviderResponseError("upstream rejected", provider="anthropic"))
+    budget = BudgetEnforcer(total="1.00")
+
+    with pytest.raises(ProviderResponseError):
+        async for _ in run_agent_loop_stream(
+            client,
+            [ChatMessage(role="user", content="Hi")],
+            budget=budget,
+        ):
+            pass
+
+    assert budget.state.reserved == 0, (
+        "reservation leaked; the exception path did not call budget.settle"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_closes_llm_span_on_provider_error():
+    """The inner LLM span must be ended (with ERROR status) when
+    chat_stream raises, so observability doesn't see it as still
+    in-flight after the overall run aborts.
+    """
+    client = _RaisingStreamClient(ProviderResponseError("upstream rejected", provider="anthropic"))
+    tracker = SpanTracker(trace_id="test-trace")
+
+    with pytest.raises(ProviderResponseError):
+        async for _ in run_agent_loop_stream(
+            client,
+            [ChatMessage(role="user", content="Hi")],
+            span_tracker=tracker,
+        ):
+            pass
+
+    spans = tracker.get_spans()
+    # All spans must be closed (ended_at set) so the trace is well-formed.
+    assert spans, "expected at least the root span to be created"
+    for span in spans:
+        assert span.ended_at is not None, f"span {span.executor_type}/{span.span_id} was left open"
+    # The llm_call span specifically should be ERROR, not OK.
+    llm_spans = [s for s in spans if s.executor_type == "llm_call"]
+    assert llm_spans, "llm_call span should have been started"
+    assert llm_spans[0].status == "ERROR"

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -66,6 +66,34 @@ def _finish_event(stop_reason: str = "end_turn") -> MagicMock:
     return event
 
 
+def _tool_use_start_event(tool_id: str, tool_name: str) -> MagicMock:
+    event = MagicMock()
+    event.type = "content_block_start"
+    event.content_block = MagicMock()
+    event.content_block.type = "tool_use"
+    event.content_block.id = tool_id
+    event.content_block.name = tool_name
+    return event
+
+
+def _tool_input_delta_event(partial_json: str) -> MagicMock:
+    event = MagicMock()
+    event.type = "content_block_delta"
+    event.delta = MagicMock()
+    # Mirror the real Anthropic SDK: a tool-input delta has
+    # ``partial_json`` and no ``text``. The provider distinguishes
+    # via hasattr on each, so explicitly delete the wrong-shape attrs.
+    event.delta.partial_json = partial_json
+    del event.delta.text
+    return event
+
+
+def _content_block_stop_event() -> MagicMock:
+    event = MagicMock()
+    event.type = "content_block_stop"
+    return event
+
+
 @pytest.mark.asyncio
 async def test_chat_stream_raises_on_empty_stream() -> None:
     """Stream with zero events == upstream silent rejection."""
@@ -104,6 +132,36 @@ async def test_chat_stream_does_not_raise_when_only_finish_reason() -> None:
         chunks.append(chunk)
 
     assert any(c.finish_reason == "end_turn" for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_does_not_raise_on_tool_only_response() -> None:
+    """A tool-only response (no text) is a normal path when tools are
+    enabled. The empty-stream guard must not misfire here.
+    """
+    client = _make_client(
+        events=[
+            _tool_use_start_event(tool_id="toolu_1", tool_name="search"),
+            _tool_input_delta_event(partial_json='{"query": '),
+            _tool_input_delta_event(partial_json='"hello"}'),
+            _content_block_stop_event(),
+            _finish_event(stop_reason="tool_use"),
+        ]
+    )
+
+    chunks: list[Any] = []
+    async for chunk in client.chat_stream(messages=[]):
+        chunks.append(chunk)
+
+    # No text deltas — but the tool call must be emitted as a StreamChunk
+    # with parsed arguments, and the run must not raise.
+    tool_chunks = [c for c in chunks if c.delta_tool_calls]
+    assert len(tool_chunks) == 1
+    tool_call = tool_chunks[0].delta_tool_calls[0]
+    assert tool_call.id == "toolu_1"
+    assert tool_call.name == "search"
+    assert tool_call.arguments == {"query": "hello"}
+    assert any(c.finish_reason == "tool_use" for c in chunks)
 
 
 def test_provider_response_error_carries_user_message() -> None:

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -1,0 +1,120 @@
+"""Tests for the Anthropic provider — format conversion and stream guards."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from aceteam_aep.providers import ProviderResponseError
+from aceteam_aep.providers.anthropic import AnthropicClient
+
+
+class _FakeAsyncStream:
+    """Minimal stand-in for ``anthropic.AsyncMessageStream``.
+
+    The real SDK returns an async context manager that yields raw stream
+    events. We only need to drive ``chat_stream`` with a scripted event
+    list, so we re-implement the protocol manually.
+    """
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+
+    async def __aenter__(self) -> _FakeAsyncStream:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        async def _gen() -> AsyncIterator[Any]:
+            for event in self._events:
+                yield event
+
+        return _gen()
+
+
+def _make_client(events: list[Any]) -> AnthropicClient:
+    client = AnthropicClient(api_key="test", model="claude-test")
+    client._client = MagicMock()
+    client._client.messages.stream = MagicMock(return_value=_FakeAsyncStream(events))
+    return client
+
+
+def _text_event(text: str) -> MagicMock:
+    event = MagicMock()
+    event.type = "content_block_delta"
+    event.delta = MagicMock()
+    event.delta.text = text
+    # The provider uses ``hasattr(event.delta, "partial_json")`` to
+    # discriminate text vs. tool-input deltas — ensure the attribute
+    # really is absent here.
+    del event.delta.partial_json
+    return event
+
+
+def _finish_event(stop_reason: str = "end_turn") -> MagicMock:
+    event = MagicMock()
+    event.type = "message_delta"
+    event.delta = MagicMock()
+    event.delta.stop_reason = stop_reason
+    event.usage = MagicMock()
+    event.usage.output_tokens = 12
+    return event
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_raises_on_empty_stream() -> None:
+    """Stream with zero events == upstream silent rejection."""
+    client = _make_client(events=[])
+
+    with pytest.raises(ProviderResponseError) as exc_info:
+        async for _ in client.chat_stream(messages=[]):
+            pass
+
+    assert exc_info.value.provider == "anthropic"
+    assert "claude-test" in str(exc_info.value)
+    assert exc_info.value.user_message  # always present
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_does_not_raise_on_text() -> None:
+    """A normal text response must not trip the empty-stream guard."""
+    client = _make_client(events=[_text_event("hello"), _finish_event()])
+
+    chunks: list[Any] = []
+    async for chunk in client.chat_stream(messages=[]):
+        chunks.append(chunk)
+
+    # delta_text + finish_reason chunks
+    assert any(c.delta_text == "hello" for c in chunks)
+    assert any(c.finish_reason == "end_turn" for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_does_not_raise_when_only_finish_reason() -> None:
+    """A finish-reason without text is rare but legal (e.g., refusal). Don't raise."""
+    client = _make_client(events=[_finish_event(stop_reason="end_turn")])
+
+    chunks: list[Any] = []
+    async for chunk in client.chat_stream(messages=[]):
+        chunks.append(chunk)
+
+    assert any(c.finish_reason == "end_turn" for c in chunks)
+
+
+def test_provider_response_error_carries_user_message() -> None:
+    err = ProviderResponseError("upstream rejected", provider="anthropic")
+    assert err.provider == "anthropic"
+    assert err.user_message
+    assert "API key" in err.user_message
+
+    err2 = ProviderResponseError(
+        "x",
+        provider="anthropic",
+        user_message="custom user-facing copy",
+    )
+    assert err2.user_message == "custom user-facing copy"


### PR DESCRIPTION
## Context

Surfaces a class of silent provider failure that's been costing real debugging time downstream. During the AceTeam chat-first launch (aceteam-ai/aceteam#3158), a revoked Anthropic BYOK key produced an assistant reply that looked blank in the UI — no error, no token usage, no log line. The multi-hour root cause chase ended in this provider: the Anthropic SDK was being given a request the upstream couldn't fulfil, returning a 200 SSE stream that closed with zero events. The SDK does not raise in that path (it only raises on explicit `event: error` SSE frames or non-2xx HTTP), and `AnthropicClient.chat_stream` here was iterating to completion without observing the silence.

The user-visible symptom was a blank message bubble. The systemic problem was that the same response shape — successful stream, no content — returns control to callers indistinguishable from a successful empty reply. Without a typed signal here, every downstream consumer has to re-discover the failure mode on its own.

## Summary

| Change | Why |
| --- | --- |
| New `providers/errors.py` with `ProviderResponseError` | Typed signal carrying `provider` slug and pre-canned `user_message` so callers (LangChain wrappers, FastAPI services, CLIs) can map cleanly to a user-safe message without scraping `str(e)`. |
| Empty-stream guard in `AnthropicClient.chat_stream` | After the `async with` block, if no text delta, no tool-call, and no stop-reason event were observed, raise `ProviderResponseError`. Conservative — a legitimate empty reply still emits `message_delta` with a `stop_reason`, so this only fires for true silent rejections. |
| Re-exports from `aceteam_aep` and `aceteam_aep.providers` | First-class API, not a buried module path. |

## How to apply

```python
from aceteam_aep import ProviderResponseError

try:
    async for chunk in client.chat_stream(messages):
        ...
except ProviderResponseError as e:
    # e.provider == "anthropic"
    # e.user_message is short, end-user-safe copy
    surface_to_user(e.user_message)
```

## Test plan

| Test | Coverage |
| --- | --- |
| `test_chat_stream_raises_on_empty_stream` | Zero-event stream → raises with provider slug |
| `test_chat_stream_does_not_raise_on_text` | Normal text+finish path is unaffected |
| `test_chat_stream_does_not_raise_when_only_finish_reason` | Refusal-style empty-content responses still pass through |
| `test_provider_response_error_carries_user_message` | Default + custom `user_message` semantics |

4 new tests in `tests/test_providers/test_anthropic.py`, all passing.
Pre-existing failures on `main` (`test_custom_policies_api.py`, dashboard
template tests) are unrelated and remain.

## Follow-ups

- `providers/openai.py`, `providers/google.py`, `providers/xai.py`,
  `providers/ollama.py` share the same pattern (iterate SDK stream,
  exit silently on empty). Same fix should be applied; deliberately
  scoped to Anthropic in this PR since that's the one we've
  confirmed in production. Each provider's empty-detection logic will
  differ slightly (OpenAI exposes `chunk.choices[0].finish_reason`
  on the terminal chunk; Google's `usage_metadata` is always present)
  so a uniform helper is premature until we see one more concrete case.

## Related

- aceteam-ai/aceteam#3235 — AceTeam chat worker surfaces the failure
  to end-users today via a defensive guard. After this lands and a
  release ships, the AceTeam-side change will switch to consuming
  `ProviderResponseError.user_message` directly for more precise copy.

---
*Generated by Claude*