### PR TITLE
Omit temperature for no-temperature Anthropic models via explicit supports_temperature param

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aceteam-aep"
-version = "0.11.1"
+version = "0.11.2"
 description = "Agentic Execution Protocol™ (AEP™) - trust & safety infrastructure for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/aceteam_aep/factory.py
+++ b/src/aceteam_aep/factory.py
@@ -19,6 +19,7 @@ def create_client(
     base_url: str | None = None,
     temperature: float = 0.7,
     max_tokens: int = 4096,
+    supports_temperature: bool = True,
     **kwargs: Any,
 ) -> ChatClient:
     """Create a ChatClient for the given model.
@@ -33,6 +34,14 @@ def create_client(
         base_url: Custom API base URL.
         temperature: Default temperature.
         max_tokens: Default max output tokens.
+        supports_temperature: When False, the ``temperature`` parameter is
+            never sent to the provider. Callers should drive this from their
+            model catalog (e.g. ``model_pricing.no_temperature``) so that new
+            no-temperature models — claude-opus-4-8, claude-sonnet-5 and
+            successors that 400 when ``temperature`` is present — are handled
+            without an aceteam-aep release. Defaults to True (unchanged
+            behavior). Currently honored by the Anthropic and OpenAI-family
+            clients.
 
     Returns:
         A ChatClient instance for the detected/specified provider.
@@ -45,6 +54,7 @@ def create_client(
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
+            supports_temperature=supports_temperature,
         )
 
     if detected == "google":
@@ -84,6 +94,7 @@ def create_client(
         base_url=url,
         temperature=temperature,
         max_tokens=max_tokens,
+        supports_temperature=supports_temperature,
     )
 
 

--- a/src/aceteam_aep/providers/anthropic.py
+++ b/src/aceteam_aep/providers/anthropic.py
@@ -124,11 +124,18 @@ class AnthropicClient:
         model: str,
         temperature: float = 0.7,
         max_tokens: int = 4096,
+        supports_temperature: bool = True,
     ) -> None:
         self._client = anthropic.AsyncAnthropic(api_key=api_key)
         self._model = model
         self._temperature = temperature
         self._max_tokens = max_tokens
+        # When False, the ``temperature`` key is never sent to the API.
+        # Newer Anthropic models (e.g. claude-opus-4-8, claude-sonnet-5)
+        # reject the request outright if ``temperature`` is present. The
+        # caller drives this from the model catalog rather than a hardcoded
+        # registry so new no-temperature models don't require an AEP release.
+        self._supports_temperature = supports_temperature
 
     @property
     def model_name(self) -> str:
@@ -148,9 +155,11 @@ class AnthropicClient:
         kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": formatted,
-            "temperature": temperature if temperature is not None else self._temperature,
             "max_tokens": max_tokens if max_tokens is not None else self._max_tokens,
         }
+
+        if self._supports_temperature:
+            kwargs["temperature"] = temperature if temperature is not None else self._temperature
 
         if system_prompt:
             kwargs["system"] = system_prompt
@@ -219,9 +228,11 @@ class AnthropicClient:
         kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": formatted,
-            "temperature": temperature if temperature is not None else self._temperature,
             "max_tokens": max_tokens if max_tokens is not None else self._max_tokens,
         }
+
+        if self._supports_temperature:
+            kwargs["temperature"] = temperature if temperature is not None else self._temperature
 
         if system_prompt:
             kwargs["system"] = system_prompt

--- a/src/aceteam_aep/providers/openai.py
+++ b/src/aceteam_aep/providers/openai.py
@@ -134,11 +134,17 @@ class OpenAIClient:
         base_url: str | None = None,
         temperature: float = 0.7,
         max_tokens: int = 4096,
+        supports_temperature: bool = True,
     ) -> None:
         self._client = openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
         self._model = model
         self._temperature = temperature
         self._max_tokens = max_tokens
+        # Explicit caller-supplied override. When False, ``temperature`` is
+        # never sent regardless of the registry guard below. Defaults to True
+        # so the registry-driven ``_supports_temperature(model)`` check remains
+        # the sole gate for existing callers (backward compatible).
+        self._supports_temperature = supports_temperature
 
     @property
     def model_name(self) -> str:
@@ -162,7 +168,7 @@ class OpenAIClient:
             token_param: max_tokens if max_tokens is not None else self._max_tokens,
         }
 
-        if _supports_temperature(self._model):
+        if self._supports_temperature and _supports_temperature(self._model):
             kwargs["temperature"] = temperature if temperature is not None else self._temperature
 
         if tools:
@@ -207,7 +213,7 @@ class OpenAIClient:
             "stream_options": {"include_usage": True},
         }
 
-        if _supports_temperature(self._model):
+        if self._supports_temperature and _supports_temperature(self._model):
             kwargs["temperature"] = temperature if temperature is not None else self._temperature
 
         if tools:

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from aceteam_aep import create_client
 from aceteam_aep.providers import StreamFailedError
 from aceteam_aep.providers.anthropic import AnthropicClient
 
@@ -167,3 +168,86 @@ def test_stream_failed_error_carries_provider_slug() -> None:
     err = StreamFailedError("upstream rejected", provider="anthropic")
     assert err.provider == "anthropic"
     assert "upstream rejected" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# supports_temperature — newer Anthropic models (claude-opus-4-8,
+# claude-sonnet-5) 400 if ``temperature`` is sent at all. The caller drives
+# omission via ``create_client(..., supports_temperature=False)``, which must
+# keep the key out of the kwargs passed to the underlying SDK entirely.
+# ---------------------------------------------------------------------------
+
+
+def _make_nonstream_response() -> MagicMock:
+    """A minimal ``messages.create`` return value that ``chat()`` can parse.
+
+    ``content`` must be a real (empty) list so the block-iteration loop
+    doesn't blow up, and usage/model/stop_reason must be real scalars.
+    """
+    response = MagicMock()
+    response.content = []
+    response.usage = MagicMock()
+    response.usage.input_tokens = 3
+    response.usage.output_tokens = 5
+    response.model = "claude-opus-4-8"
+    response.stop_reason = "end_turn"
+    return response
+
+
+def _make_factory_client(*, supports_temperature: bool) -> AnthropicClient:
+    """Build the client through the public factory, then swap in a mock SDK."""
+    client = create_client(
+        model="claude-opus-4-8",
+        api_key="test",
+        provider="anthropic",
+        supports_temperature=supports_temperature,
+    )
+    assert isinstance(client, AnthropicClient)
+    client._client = MagicMock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_chat_omits_temperature_when_unsupported() -> None:
+    client = _make_factory_client(supports_temperature=False)
+    create_mock = AsyncMock(return_value=_make_nonstream_response())
+    client._client.messages.create = create_mock
+
+    await client.chat(messages=[])
+
+    assert "temperature" not in create_mock.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_chat_includes_temperature_by_default() -> None:
+    client = _make_factory_client(supports_temperature=True)
+    create_mock = AsyncMock(return_value=_make_nonstream_response())
+    client._client.messages.create = create_mock
+
+    await client.chat(messages=[])
+
+    assert "temperature" in create_mock.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_omits_temperature_when_unsupported() -> None:
+    client = _make_factory_client(supports_temperature=False)
+    stream_mock = MagicMock(return_value=_FakeAsyncStream([_finish_event()]))
+    client._client.messages.stream = stream_mock
+
+    async for _ in client.chat_stream(messages=[]):
+        pass
+
+    assert "temperature" not in stream_mock.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_includes_temperature_by_default() -> None:
+    client = _make_factory_client(supports_temperature=True)
+    stream_mock = MagicMock(return_value=_FakeAsyncStream([_finish_event()]))
+    client._client.messages.stream = stream_mock
+
+    async for _ in client.chat_stream(messages=[]):
+        pass
+
+    assert "temperature" in stream_mock.call_args.kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aceteam-aep"
-version = "0.11.0"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Problem

Newer Anthropic models (`claude-opus-4-8`, `claude-sonnet-5`) return `400 "temperature is deprecated for this model"` if `temperature` is sent at all. The aceteam gateway path was fixed in aceteam-ai/aceteam#5410, but the **primary path** — agent chat (`chat_with_agent` -> `agent_response.py` -> `create_agent_model` -> `agents/model.py` -> `aceteam_aep.create_client()` -> `AnthropicClient.chat`) — is still broken: `AnthropicClient.chat`/`chat_stream` put `"temperature": temperature if temperature is not None else self._temperature` into the request kwargs **unconditionally**, and there was no way through the public `create_client` API to omit the key (`temperature=None` falls back to `self._temperature=0.7`).

The OpenAI provider in this package already guards temperature via `_supports_temperature(model)` / `get_model_info().supports_temperature`; the Anthropic provider never got that treatment.

## Fix: explicit param, not the AEP registry

The source of truth for which models are no-temperature is the aceteam DB catalog (`model_pricing.no_temperature`), and the caller passes it in. Making AEP's hardcoded `models.py` registry authoritative would force an AEP re-release every time a new no-temperature model is seeded — the exact "necessary but not sufficient" failure we are killing.

So capability is driven by an **explicit boolean threaded through the public API**:

- `create_client(..., supports_temperature: bool = True)` new param.
- Threaded into `AnthropicClient.__init__` (stored as `self._supports_temperature`). In both `chat` and `chat_stream`, the `temperature` key enters the request kwargs **only** inside `if self._supports_temperature:`. When `False`, the key is omitted entirely (not set to `None`, not clamped).
- Threaded into `OpenAIClient.__init__` for parity. Its guard becomes `if self._supports_temperature and _supports_temperature(self._model):` — the AND keeps the registry check as the sole gate when the param is left at its `True` default (byte-identical existing behavior) and lets an explicit `False` force-omit.
- Default `supports_temperature=True` everywhere -> fully backward compatible; only an explicit `False` changes behavior.

`create_client` fans out directly to concrete provider clients (`ChatClient` is a bare `Protocol`, no wrapper), so no extra routing was needed. The `xai`/`ollama` clients subclass `OpenAIClient` and the `google` client is separate; they are left to inherit the `True` default (explicit-param not threaded to them) since the bug and the aceteam use case are Anthropic + OpenAI-family. That is a deliberate, truthful scope boundary, not a defect.

## Test evidence

Added to `tests/test_providers/test_anthropic.py`, all driving the **public** `create_client(provider="anthropic", ...)` factory then asserting on the kwargs captured by a mocked SDK:

- `test_chat_omits_temperature_when_unsupported` — `supports_temperature=False` -> no `temperature` key in `messages.create` kwargs.
- `test_chat_includes_temperature_by_default` — default -> `temperature` present.
- `test_chat_stream_omits_temperature_when_unsupported` — `supports_temperature=False` -> no `temperature` key in `messages.stream` kwargs.
- `test_chat_stream_includes_temperature_by_default` — default -> `temperature` present.

Results: `tests/test_providers/test_anthropic.py` 9 passed (5 existing + 4 new). Full suite: **606 passed, 4 failed, 34 skipped**. The 4 failures (`test_custom_policies_api::test_crud_flow`, `test_dashboard::test_dashboard_returns_200`, `test_dashboard::test_ciso_route_returns_200`, `test_proxy::test_dashboard_at_dashboard_path`) are **pre-existing and unrelated** — dashboard/policy HTTP-response assertions with no interaction with provider temperature handling. They reproduce identically on the `v0.11.1` base in this environment (a baseline run with these changes reverted produced the same 4 failures, 602 passed; the +4 delta is exactly the new Anthropic tests). The 34 skipped are integration tests that skip without `OPENAI_API_KEY`. `ruff check` + `ruff format --check` clean on changed files. `pyright` error count unchanged vs `v0.11.1` baseline (35 == 35; all pre-existing, none on new lines).

Version bumped to `0.11.2` so the eventual publish is ready. **Not published.**

## Deploy chain (all gated on Jason, do NOT auto-fire)

1. Publish `aceteam-aep` `0.11.2` to PyPI.
2. Bump the `aceteam-aep>=0.11.1` pin in aceteam to `>=0.11.2`.
3. Thread `supports_temperature` through `create_agent_model` / `_build_client_from_route` from `route.model.no_temperature` (i.e. `supports_temperature=not route.model.no_temperature`).
4. Deploy aceteam.
5. Re-activate `claude-opus-4-8` / `claude-sonnet-5` in `model_pricing`.
6. Verify a real agent chat returns 200.

Second half of aceteam-ai/aceteam#5398 (first half was aceteam-ai/aceteam#5410 on the gateway path). #5398 stays open after this.

Requested by Jason.
