### PR TITLE
fix(openai): dotted gpt-5.x models now use max_completion_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 ### Changed
 ### Fixed
 
+## [0.11.3] - 2026-07-11
+
+### Fixed
+- **OpenAI dotted `gpt-5.x` point releases (`gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.1`, ...) now correctly use `max_completion_tokens`.** These models aren't in `MODEL_REGISTRY` yet, so `_uses_max_completion_tokens()` fell back to a dash-only prefix check (`model.startswith("gpt-5-")`), which a dotted name never matches. The client sent `max_tokens` and OpenAI returned `400 Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.` Confirmed live against the OpenAI API for `gpt-5.6-terra`, `gpt-5.4`, and `gpt-5`.
+- **Same dotted-name fallback bug in `_supports_temperature()`.** Dotted `gpt-5.x` models were wrongly treated as accepting a `temperature` parameter. Both fallbacks now share a single `_matches_family()` helper (tolerating `-` and `.` separators) so they can't drift apart again.
+
+### Added
+- **`uses_max_completion_tokens: bool | None` on `OpenAIClient.__init__` and `create_client()`.** Mirrors the existing `supports_temperature` override. Defaults to `None` (unchanged behavior — the registry/prefix heuristic decides); when set to `True`/`False` it forces the token-limit param regardless of model name. Gives the aceteam side a per-model lever without waiting on an aceteam-aep release. No registry entries were added for the new models; the fallback heuristic is the load-bearing fix.
+
 ## [0.6.0] - 2026-04-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aceteam-aep"
-version = "0.11.2"
+version = "0.11.3"
 description = "Agentic Execution Protocol™ (AEP™) - trust & safety infrastructure for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/aceteam_aep/factory.py
+++ b/src/aceteam_aep/factory.py
@@ -20,6 +20,7 @@ def create_client(
     temperature: float = 0.7,
     max_tokens: int = 4096,
     supports_temperature: bool = True,
+    uses_max_completion_tokens: bool | None = None,
     **kwargs: Any,
 ) -> ChatClient:
     """Create a ChatClient for the given model.
@@ -42,6 +43,13 @@ def create_client(
             without an aceteam-aep release. Defaults to True (unchanged
             behavior). Currently honored by the Anthropic and OpenAI-family
             clients.
+        uses_max_completion_tokens: When not None, overrides the OpenAI-family
+            client's ``max_completion_tokens`` vs. ``max_tokens`` heuristic.
+            Defaults to None, in which case the registry/prefix-driven
+            ``_uses_max_completion_tokens(model)`` check in
+            ``providers/openai.py`` decides (unchanged behavior). Only
+            honored by the OpenAI-family client (OpenAI, xAI, Ollama, and
+            other OpenAI-compatible endpoints go through ``OpenAIClient``).
 
     Returns:
         A ChatClient instance for the detected/specified provider.
@@ -95,6 +103,7 @@ def create_client(
         temperature=temperature,
         max_tokens=max_tokens,
         supports_temperature=supports_temperature,
+        uses_max_completion_tokens=uses_max_completion_tokens,
     )
 
 

--- a/src/aceteam_aep/factory.py
+++ b/src/aceteam_aep/factory.py
@@ -43,13 +43,18 @@ def create_client(
             without an aceteam-aep release. Defaults to True (unchanged
             behavior). Currently honored by the Anthropic and OpenAI-family
             clients.
-        uses_max_completion_tokens: When not None, overrides the OpenAI-family
-            client's ``max_completion_tokens`` vs. ``max_tokens`` heuristic.
-            Defaults to None, in which case the registry/prefix-driven
+        uses_max_completion_tokens: When not None, overrides the
+            ``max_completion_tokens`` vs. ``max_tokens`` heuristic. Defaults
+            to None, in which case the registry/prefix-driven
             ``_uses_max_completion_tokens(model)`` check in
             ``providers/openai.py`` decides (unchanged behavior). Only
-            honored by the OpenAI-family client (OpenAI, xAI, Ollama, and
-            other OpenAI-compatible endpoints go through ``OpenAIClient``).
+            honored on the direct OpenAI / OpenAI-compatible path below
+            (OpenAI, SambaNova, TheAgentic, DeepSeek, and other
+            OpenAI-compatible ``base_url`` endpoints go through
+            ``OpenAIClient`` directly). NOT currently threaded through to
+            ``XAIClient`` or ``OllamaClient`` — those subclasses'
+            ``__init__`` don't accept it yet, same as ``supports_temperature``
+            above, so setting it has no effect for xai/ollama models.
 
     Returns:
         A ChatClient instance for the detected/specified provider.

--- a/src/aceteam_aep/providers/openai.py
+++ b/src/aceteam_aep/providers/openai.py
@@ -84,14 +84,35 @@ def _parse_tool_calls(
     return result
 
 
+def _matches_family(model: str, prefixes: tuple[str, ...]) -> bool:
+    """Match a model against family prefixes, tolerating both dash- and
+    dot-separated variants (``gpt-5-mini``, ``gpt-5.6-terra``) and the bare
+    family name (``gpt-5``).
+
+    OpenAI has started shipping dotted point-release names for the ``gpt-5``
+    family (``gpt-5.1``, ``gpt-5.4-mini``, ``gpt-5.6-terra``, ...). A naive
+    ``model.startswith(prefix + "-")`` check misses these because the
+    separator after the family name is a dot, not a dash. This helper is the
+    single place both fallback heuristics below consult so they can never
+    drift apart again.
+    """
+    return any(model == p or model.startswith((p + "-", p + ".")) for p in prefixes)
+
+
+# Family prefixes for OpenAI reasoning models that (a) require
+# max_completion_tokens instead of max_tokens and (b) don't accept a
+# temperature parameter. Used as a fallback for models not yet seeded into
+# the registry (see MODEL_REGISTRY in models.py).
+_REASONING_FAMILY_PREFIXES: tuple[str, ...] = ("o1", "o3", "gpt-5")
+
+
 def _uses_max_completion_tokens(model: str) -> bool:
     """Return True if the model requires max_completion_tokens instead of max_tokens."""
     info = get_model_info(model)
     if info is not None:
         return info.uses_max_completion_tokens
     # Fallback prefix check for models not yet in the registry.
-    prefixes = ("o1", "o3", "gpt-5")
-    return any(model == p or model.startswith(p + "-") for p in prefixes)
+    return _matches_family(model, _REASONING_FAMILY_PREFIXES)
 
 
 def _supports_temperature(model: str) -> bool:
@@ -99,9 +120,8 @@ def _supports_temperature(model: str) -> bool:
     info = get_model_info(model)
     if info is not None:
         return info.supports_temperature
-    # Fallback: o1, o3, gpt-5 don't support temperature
-    prefixes = ("o1", "o3", "gpt-5")
-    return not any(model == p or model.startswith(p + "-") for p in prefixes)
+    # Fallback: o1, o3, gpt-5 (and dotted point releases) don't support temperature.
+    return not _matches_family(model, _REASONING_FAMILY_PREFIXES)
 
 
 def _extract_usage(usage: Any) -> Usage:
@@ -135,6 +155,7 @@ class OpenAIClient:
         temperature: float = 0.7,
         max_tokens: int = 4096,
         supports_temperature: bool = True,
+        uses_max_completion_tokens: bool | None = None,
     ) -> None:
         self._client = openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
         self._model = model
@@ -145,6 +166,13 @@ class OpenAIClient:
         # so the registry-driven ``_supports_temperature(model)`` check remains
         # the sole gate for existing callers (backward compatible).
         self._supports_temperature = supports_temperature
+        # Explicit caller-supplied override for which token-limit param to
+        # send. When None (the default), the registry/prefix-driven
+        # ``_uses_max_completion_tokens(model)`` heuristic decides, so
+        # existing callers are unaffected. Mirrors ``supports_temperature``
+        # above: an inert lever for the aceteam side to flip per-model
+        # without waiting on an aceteam-aep release.
+        self._uses_max_completion_tokens = uses_max_completion_tokens
 
     @property
     def model_name(self) -> str:
@@ -159,9 +187,11 @@ class OpenAIClient:
         max_tokens: int | None = None,
         response_format: dict[str, Any] | None = None,
     ) -> ChatResponse:
-        token_param = (
-            "max_completion_tokens" if _uses_max_completion_tokens(self._model) else "max_tokens"
-        )
+        if self._uses_max_completion_tokens is not None:
+            uses_mct = self._uses_max_completion_tokens
+        else:
+            uses_mct = _uses_max_completion_tokens(self._model)
+        token_param = "max_completion_tokens" if uses_mct else "max_tokens"
         kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": _format_messages(messages),
@@ -202,9 +232,11 @@ class OpenAIClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
     ) -> AsyncIterator[StreamChunk]:
-        token_param = (
-            "max_completion_tokens" if _uses_max_completion_tokens(self._model) else "max_tokens"
-        )
+        if self._uses_max_completion_tokens is not None:
+            uses_mct = self._uses_max_completion_tokens
+        else:
+            uses_mct = _uses_max_completion_tokens(self._model)
+        token_param = "max_completion_tokens" if uses_mct else "max_tokens"
         kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": _format_messages(messages),

--- a/tests/test_providers/test_openai.py
+++ b/tests/test_providers/test_openai.py
@@ -10,7 +10,12 @@ import pytest
 
 from aceteam_aep.models import MODEL_REGISTRY, get_model_info
 from aceteam_aep.providers import StreamFailedError
-from aceteam_aep.providers.openai import OpenAIClient, _format_messages, _uses_max_completion_tokens
+from aceteam_aep.providers.openai import (
+    OpenAIClient,
+    _format_messages,
+    _supports_temperature,
+    _uses_max_completion_tokens,
+)
 from aceteam_aep.types import ChatMessage, ContentBlock, ToolCallRequest
 
 
@@ -95,6 +100,50 @@ def test_uses_max_completion_tokens():
         assert not _uses_max_completion_tokens(model), f"{model} should use max_tokens"
 
 
+def test_uses_max_completion_tokens_dotted_gpt5_variants():
+    """Dotted point-release gpt-5.x names (not yet in the registry) must
+    still hit the max_completion_tokens fallback via prefix matching.
+
+    Regression test for aceteam-ai/aceteam#5566: OpenAI's dotted names
+    (gpt-5.6-terra, gpt-5.4, ...) previously fell through the dash-only
+    prefix check and 400'd with "max_tokens is not supported".
+    """
+    dotted_mct_models = (
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "gpt-5.1",
+        "gpt-5",
+        "o3-mini",
+    )
+    for model in dotted_mct_models:
+        assert _uses_max_completion_tokens(model), f"{model} should use max_completion_tokens"
+
+    for model in ("gpt-4o", "gpt-4.5-preview"):
+        assert not _uses_max_completion_tokens(model), f"{model} should use max_tokens"
+
+
+def test_supports_temperature_dotted_gpt5_variants():
+    """The parallel fallback for temperature support must not drift from
+    _uses_max_completion_tokens - both consult the same _matches_family
+    helper so a dotted gpt-5.x model (not yet in the registry) is treated
+    as no-temperature too."""
+    for model in ("gpt-5.6-terra", "gpt-5.4"):
+        assert not _supports_temperature(model), f"{model} should not support temperature"
+
+    assert _supports_temperature("gpt-4o")
+
+    # Exact "gpt-5" is a registry hit, not a fallback case: the registry
+    # entry for gpt-5 doesn't set supports_temperature=False, so this
+    # fallback fix does not change (and must not be asserted about) its
+    # temperature behavior. See MODEL_REGISTRY in models.py.
+    assert _supports_temperature("gpt-5")
+
+
 def test_registry_drives_max_completion_tokens():
     """_uses_max_completion_tokens must agree with the registry for all known models."""
     for model, info in MODEL_REGISTRY.items():
@@ -141,6 +190,79 @@ def _make_stream_client(chunks: list[Any]) -> OpenAIClient:
 
     client._client.chat.completions.create = _fake_create
     return client
+
+
+def _make_completion_response(model: str = "gpt-test") -> MagicMock:
+    """Stand-in for the OpenAI SDK's non-streaming ChatCompletion object."""
+    response = MagicMock()
+    response.model = model
+    response.usage = None
+    choice = MagicMock()
+    choice.message = MagicMock()
+    choice.message.content = "ok"
+    choice.message.tool_calls = None
+    choice.finish_reason = "stop"
+    response.choices = [choice]
+    return response
+
+
+def _make_capturing_client(
+    model: str = "gpt-test", **client_kwargs: Any
+) -> tuple[OpenAIClient, dict[str, Any]]:
+    """Return an OpenAIClient plus a dict that captures the kwargs passed to
+    the underlying SDK ``create`` call (for both chat() and chat_stream())."""
+    client = OpenAIClient(api_key="test", model=model, **client_kwargs)
+    client._client = MagicMock()
+    captured: dict[str, Any] = {}
+
+    async def _fake_create(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        if kwargs.get("stream"):
+            return _AsyncChunkIterator([_make_choice_chunk(content="hi", finish_reason="stop")])
+        return _make_completion_response(model=model)
+
+    client._client.chat.completions.create = _fake_create
+    return client, captured
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_max_completion_tokens_override_true() -> None:
+    """A model that would normally use max_tokens (gpt-4o) must send
+    max_completion_tokens when the override forces it True."""
+    client, captured = _make_capturing_client(model="gpt-4o", uses_max_completion_tokens=True)
+    await client.chat(messages=[])
+    assert "max_completion_tokens" in captured
+    assert "max_tokens" not in captured
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_max_completion_tokens_override_false() -> None:
+    """A model that would normally use max_completion_tokens (gpt-5) must
+    send max_tokens when the override forces it False."""
+    client, captured = _make_capturing_client(model="gpt-5", uses_max_completion_tokens=False)
+    await client.chat(messages=[])
+    assert "max_tokens" in captured
+    assert "max_completion_tokens" not in captured
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_max_completion_tokens_default_follows_heuristic() -> None:
+    """With no override (the default), behavior is unchanged: the dotted
+    gpt-5.x fallback heuristic decides."""
+    client, captured = _make_capturing_client(model="gpt-5.6-terra")
+    await client.chat(messages=[])
+    assert "max_completion_tokens" in captured
+    assert "max_tokens" not in captured
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_uses_max_completion_tokens_override() -> None:
+    """The same override must also apply to chat_stream()'s token param."""
+    client, captured = _make_capturing_client(model="gpt-4o", uses_max_completion_tokens=True)
+    async for _ in client.chat_stream(messages=[]):
+        pass
+    assert "max_completion_tokens" in captured
+    assert "max_tokens" not in captured
 
 
 def _make_choice_chunk(

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aceteam-aep"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Root cause

`_uses_max_completion_tokens(model)` in `src/aceteam_aep/providers/openai.py` checks the registry first, then falls back to a prefix check for models not yet seeded into `MODEL_REGISTRY`:

```python
prefixes = ("o1", "o3", "gpt-5")
return any(model == p or model.startswith(p + "-") for p in prefixes)
```

OpenAI's newer dotted point-release names (`gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.1`) aren't in the registry, and `"gpt-5.6-terra".startswith("gpt-5-")` is `False` — the separator after the family name is a dot, not a dash. So the fallback returns `False`, the client sends `max_tokens`, and OpenAI 400s:

```
Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead. (code: unsupported_parameter)
```

**Confirmed live against the OpenAI API** (real key): `gpt-5.6-terra`, `gpt-5.4`, and `gpt-5` all 400 on `max_tokens` and all 200 on `max_completion_tokens`.

## Correction to #5566 — precise, not blanket

#5566 speculates that the *existing* `gpt-5` / `gpt-5-mini` registry rows "almost certainly 400 the same way" as the dotted variants and asks to verify. **On the token-param dimension that's this PR's subject, they don't.** `gpt-5` and `gpt-5-mini` are exact keys in `MODEL_REGISTRY` with `uses_max_completion_tokens=True` already set, so they hit the registry branch and already send `max_completion_tokens` correctly — verified live below with `create_client(model="gpt-5", ...)`. Only the **dotted variants**, which aren't in the registry and fall through to the broken prefix check, were sending `max_tokens`.

**Separate axis, not fixed here:** while testing `gpt-5` through the default `create_client` path (`temperature=0.7`, the factory default), I found it *does* 400 — but on `temperature`, not `max_tokens`:
```
Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.
```
`MODEL_REGISTRY`'s `gpt-5`/`gpt-5-mini`/`gpt-5-nano` rows don't set `supports_temperature=False`, so the client sends `temperature` by default. This is the #5398 axis (no-temperature models), not the #5566 axis (token param) — the fix for it is aceteam driving `create_client(..., supports_temperature=False)` from its `model_pricing.no_temperature` catalog, not a change in this repo (and out of scope per this task's "leave the registry alone" constraint — I only have live evidence for `gpt-5` itself, not `gpt-5-mini`/`gpt-5-nano`, so I'm not touching that registry default). Flagging this as a distinct follow-up: **gpt-5 family registry rows need `supports_temperature=False`** (or aceteam's catalog needs to pass the override) to avoid a live temperature-400, independent of this PR.

## Parallel bug fixed in the same pass

`_supports_temperature(model)` has the identical dash-only prefix defect, so a dotted `gpt-5.x` model (not in the registry) was also wrongly treated as accepting a `temperature` parameter. Both fallbacks now share one `_matches_family()` helper (tolerating `-` and `.` separators) so they can't drift apart again. (Ironically, this makes the dotted-name fallback *more* correct on the temperature axis than the registry-seeded `gpt-5` row today — see above.)

## Also added

An optional `uses_max_completion_tokens: bool | None = None` parameter on `OpenAIClient.__init__` and `create_client()`, mirroring the existing `supports_temperature` override. When `None` (default), the registry/prefix heuristic decides — all current callers are unaffected. When set explicitly, it forces the token-limit param regardless of model name, giving the aceteam side a per-model lever without waiting on an aceteam-aep release. Honored on the direct OpenAI/OpenAI-compatible path (`OpenAIClient`); not yet threaded through `XAIClient`/`OllamaClient` (same limitation `supports_temperature` already has).

No new registry entries were added for the gpt-5.x models — the registry-as-SSOT approach is what got us here (seeding a row isn't enough if the runtime doesn't fall back correctly for the next unseeded model); the fallback fix is what's load-bearing.

## Verification

**Unit tests** (`tests/test_providers/test_openai.py`): 19 tests passing, including new coverage for the dotted-name fallback (both functions) and the new override on `chat()`/`chat_stream()`.

**Full suite**: `uv run pytest` — 612 passed, 34 skipped, 4 pre-existing failures unrelated to this change (dashboard/proxy HTML title assertions, confirmed failing identically on `main` before this branch).

**Real completions** (installed this patched package editable into `aceteam/python-backend`'s venv, called `create_client` directly against the live OpenAI API with request logging on):

```
# gpt-5.6-terra, default create_client() call (no override needed - fallback now handles it):
Request json_data: {..., 'model': 'gpt-5.6-terra', 'max_completion_tokens': 256}
HTTP Response: "200 OK"
RESULT: ChatResponse(message=ChatMessage(role='assistant', content='OK', ...), model='gpt-5.6-terra', finish_reason='stop')

# gpt-5, with supports_temperature=False (registry already sends max_completion_tokens;
# this demonstrates the temperature lever discussed above):
Request json_data: {..., 'model': 'gpt-5', 'max_completion_tokens': 256}
HTTP Response: "200 OK"
RESULT: ChatResponse(message=ChatMessage(role='assistant', content='OK', ...), model='gpt-5-2025-08-07', finish_reason='stop')
```

No `temperature` key on the wire in either case, `max_completion_tokens` sent instead of `max_tokens`, both 200 OK with real content returned.

Related: aceteam-ai/aceteam#5566, #5398, #5385

---
*Generated by Claude (Sonnet 5)*