### PR TITLE
fix(safety): per-entity severity map for PII detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ### Changed
 ### Fixed
 
+## [0.11.4] - 2026-07-16
+
+### Fixed
+- **PII detector no longer emits every entity at `severity="high"`.** Both the NER model path and the regex path now use a per-entity-type severity map: SSN and CREDIT_CARD are "high", ID_NUM is "medium", EMAIL/PHONE/IP_ADDRESS/PERSON are "low", and unknown entity types default to "medium". Previously any email address in input (e.g. `noreply@anthropic.com` in Claude Code's system prompt) produced a "high" signal, and default enforcement policies block on "high", so the whole request was blocked. Signal emission is otherwise unchanged (spans, scores, detail strings, detector name, signal_type). Fixes aceteam-ai/aceteam#5944.
+
 ## [0.11.3] - 2026-07-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aceteam-aep"
-version = "0.11.3"
+version = "0.11.4"
 description = "Agentic Execution Protocol™ (AEP™) - trust & safety infrastructure for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/aceteam_aep/safety/pii.py
+++ b/src/aceteam_aep/safety/pii.py
@@ -21,6 +21,25 @@ _PII_ENTITIES = {
     "ID_NUM",
 }
 
+# Per-entity-type severity. Identifiers that enable direct financial/identity
+# fraud are "high"; contact info and names are "low". Unknown entity types
+# default to "medium" via _severity_for().
+_ENTITY_SEVERITY: dict[str, str] = {
+    "SSN": "high",
+    "CREDIT_CARD": "high",
+    "ID_NUM": "medium",
+    "EMAIL": "low",
+    "PHONE": "low",
+    "IP_ADDRESS": "low",
+    "PERSON": "low",
+}
+
+_DEFAULT_SEVERITY = "medium"
+
+
+def _severity_for(entity_type: str) -> str:
+    return _ENTITY_SEVERITY.get(entity_type, _DEFAULT_SEVERITY)
+
 
 def _normalize_entity_label(raw: str) -> str:
     """Strip B-/I- BIO prefixes from token-classification labels."""
@@ -168,7 +187,7 @@ class PiiDetector(SafetyDetector):
                 span_start=span_start,
                 span_end=span_end,
                 signal_type="pii",
-                severity="high",
+                severity=_severity_for(ent_type),
                 call_id=call_id,
                 detail=(
                     f"PII detected: {ent_type} "
@@ -194,7 +213,7 @@ class PiiDetector(SafetyDetector):
                     span_start=span_start,
                     span_end=span_end,
                     signal_type="pii",
-                    severity="high",
+                    severity=_severity_for(pii_type),
                     call_id=call_id,
                     detail=(f"PII pattern detected: {pii_type} [{span_start}:{span_end}] ({tag})"),
                     score=1.0,

--- a/tests/test_safety/test_pii.py
+++ b/tests/test_safety/test_pii.py
@@ -59,3 +59,106 @@ async def test_regex_fallback_works() -> None:
     )
     assert any(s.signal_type == "pii" for s in signals)
     assert any("regex fallback" in s.detail for s in signals)
+
+
+def _regex_only_detector() -> PiiDetector:
+    """Detector forced into regex fallback (no model load attempt)."""
+    det = PiiDetector(model_name="nonexistent/model-that-will-fail")
+    det._load_attempted = True
+    det._fallback = True
+    return det
+
+
+async def test_email_regex_severity_low() -> None:
+    det = _regex_only_detector()
+    signals = await det.check(
+        input_text="Contact noreply@anthropic.com for details",
+        output_text="",
+        call_id="t6",
+    )
+    email_signals = [s for s in signals if s.entity_type == "EMAIL"]
+    assert email_signals
+    assert all(s.severity == "low" for s in email_signals)
+
+
+async def test_ssn_regex_severity_high() -> None:
+    det = _regex_only_detector()
+    signals = await det.check(
+        input_text="",
+        output_text="SSN: 123-45-6789",
+        call_id="t7",
+    )
+    ssn_signals = [s for s in signals if s.entity_type == "SSN"]
+    assert ssn_signals
+    assert all(s.severity == "high" for s in ssn_signals)
+
+
+async def test_phone_regex_severity_low() -> None:
+    det = _regex_only_detector()
+    signals = await det.check(
+        input_text="",
+        output_text="Call me at (555) 123-4567",
+        call_id="t8",
+    )
+    phone_signals = [s for s in signals if s.entity_type == "PHONE"]
+    assert phone_signals
+    assert all(s.severity == "low" for s in phone_signals)
+
+
+class _FakeNerPipeline:
+    """Stand-in for the transformers token-classification pipeline."""
+
+    def __init__(self, entities: list[dict]) -> None:
+        self._entities = entities
+
+    def __call__(self, text: str) -> list[dict]:
+        return self._entities
+
+
+def _model_detector(entities: list[dict]) -> PiiDetector:
+    det = PiiDetector()
+    det._load_attempted = True
+    det._fallback = False
+    det._pipeline = _FakeNerPipeline(entities)
+    return det
+
+
+async def test_ner_path_uses_severity_map() -> None:
+    det = _model_detector(
+        [
+            {"entity_group": "PERSON", "start": 0, "end": 4, "score": 0.99},
+            {"entity_group": "IP_ADDRESS", "start": 10, "end": 19, "score": 0.95},
+            {"entity_group": "ID_NUM", "start": 25, "end": 34, "score": 0.90},
+            {"entity_group": "CREDIT_CARD", "start": 40, "end": 56, "score": 0.97},
+        ]
+    )
+    signals = await det.check(
+        input_text="John lives at 10.0.0.1, id A12345678, card 4111111111111111",
+        output_text="",
+        call_id="t9",
+    )
+    by_type = {s.entity_type: s.severity for s in signals if "PII detected" in s.detail}
+    assert by_type["PERSON"] == "low"
+    assert by_type["IP_ADDRESS"] == "low"
+    assert by_type["ID_NUM"] == "medium"
+    assert by_type["CREDIT_CARD"] == "high"
+
+
+async def test_ner_ssn_severity_high() -> None:
+    det = _model_detector([{"entity_group": "B-SSN", "start": 8, "end": 19, "score": 0.98}])
+    signals = await det.check(
+        input_text="SSN is 987-65-4321",
+        output_text="",
+        call_id="t10",
+    )
+    ssn_model_signals = [
+        s for s in signals if s.entity_type == "SSN" and "PII detected" in s.detail
+    ]
+    assert ssn_model_signals
+    assert all(s.severity == "high" for s in ssn_model_signals)
+
+
+def test_unknown_entity_type_defaults_to_medium() -> None:
+    from aceteam_aep.safety.pii import _severity_for
+
+    assert _severity_for("SOME_FUTURE_TYPE") == "medium"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aceteam-aep"
-version = "0.11.3"
+version = "0.11.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Root cause

`PiiDetector` emitted every PII signal at `severity="high"` in both the NER model path (`_check_model`) and the regex path (`_check_regex`). Default enforcement policies block on "high", so any email address in input blocked the whole request - e.g. Claude Code's system prompt contains `noreply@anthropic.com`, which made every proxied request fail.

## Fix

Module-level `_ENTITY_SEVERITY` map applied in both paths via `_severity_for()`. Signal emission is otherwise unchanged (spans, scores, detail strings, detector name, signal_type).

| Entity type | Severity |
|---|---|
| SSN, CREDIT_CARD | high |
| ID_NUM | medium |
| EMAIL, PHONE, IP_ADDRESS, PERSON | low |
| unknown entity types | medium (safe default) |

## Tests

Extended `tests/test_safety/test_pii.py`:
- EMAIL regex hit is severity "low" (uses `noreply@anthropic.com` as the repro input)
- SSN is "high" on both regex and NER paths
- PHONE regex hit is "low"
- NER path (mocked pipeline) uses the map: PERSON/IP_ADDRESS low, ID_NUM medium, CREDIT_CARD high, plus BIO-prefix normalization (`B-SSN` -> high)
- Unknown entity type defaults to "medium"

`uv run pytest tests/test_safety/`: 50 passed (real NER model loaded in this environment, so the model path was exercised for the base tests too). `ruff check`, `ruff format --check`, and `pyright` clean on changed files.

## Release

Version bumped to 0.11.4 (patch) with a CHANGELOG entry. After merge, publish with `./scripts/release.sh -v 0.11.4` (builds, tags v0.11.4, publishes to PyPI). Not run here.

Fixes aceteam-ai/aceteam#5944 (cross-repo reference for linking; auto-close does not apply across repos, close the issue manually after release).