### PR TITLE
feat(anthropic): enable prompt caching on the static prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- **Anthropic prompt caching on the static prefix.** The Anthropic client now attaches `cache_control: {"type": "ephemeral"}` breakpoints to the tool definitions and the system prompt (the last static block, which caches the tools+system prefix together). For agent/chat turns that re-send a large fixed prefix (system prompt + tool schemas) every round-trip, Anthropic now serves that prefix from cache at ~0.1x input price instead of re-billing it in full. Behavior-neutral: identical outputs, lower cost. Configurable via the `prompt_caching` param on `AnthropicClient`/`create_client()` or the `AEP_PROMPT_CACHING` env toggle (default ON; set to a false value for a byte-identical revert). Addresses aceteam-ai/aceteam#5856; follow-up to aceteam-ai/aceteam PR #5901.
+- **`Usage.cache_read_input_tokens` and `Usage.cache_creation_input_tokens`.** Anthropic's cache-token counts now surface on `Usage` (default 0; summed in `__add__`) so the host app can log and bill them. Populated from `response.usage` on the non-streaming path and from the `message_start` event on the streaming path.
+
 ### Changed
 ### Fixed
 

--- a/src/aceteam_aep/factory.py
+++ b/src/aceteam_aep/factory.py
@@ -21,6 +21,7 @@ def create_client(
     max_tokens: int = 4096,
     supports_temperature: bool = True,
     uses_max_completion_tokens: bool | None = None,
+    prompt_caching: bool | None = None,
     **kwargs: Any,
 ) -> ChatClient:
     """Create a ChatClient for the given model.
@@ -55,6 +56,12 @@ def create_client(
             ``XAIClient`` or ``OllamaClient`` — those subclasses'
             ``__init__`` don't accept it yet, same as ``supports_temperature``
             above, so setting it has no effect for xai/ollama models.
+        prompt_caching: Controls Anthropic prompt caching (``cache_control``
+            breakpoints on the static system-prompt + tool-definitions prefix).
+            When None (default), the ``AEP_PROMPT_CACHING`` env toggle decides
+            (ON unless set to a false value). Pass ``False`` to force it off.
+            Behavior-neutral (identical outputs, lower cost). Only honored by
+            the Anthropic client; ignored by other providers.
 
     Returns:
         A ChatClient instance for the detected/specified provider.
@@ -68,6 +75,7 @@ def create_client(
             temperature=temperature,
             max_tokens=max_tokens,
             supports_temperature=supports_temperature,
+            prompt_caching=prompt_caching,
         )
 
     if detected == "google":

--- a/src/aceteam_aep/providers/anthropic.py
+++ b/src/aceteam_aep/providers/anthropic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -10,6 +11,35 @@ import anthropic
 
 from ..types import ChatMessage, ChatResponse, StreamChunk, ToolCallRequest, Usage
 from .errors import StreamFailedError
+
+_CACHE_CONTROL: dict[str, str] = {"type": "ephemeral"}
+
+# Environment values that turn a boolean AEP flag off. Mirrors the truthy
+# convention used elsewhere in the package (config.py), inverted: prompt
+# caching defaults ON, so only an explicit off-value disables it.
+_ENV_FALSE = frozenset({"0", "false", "no", "off"})
+
+
+def _prompt_caching_default() -> bool:
+    """Read the ``AEP_PROMPT_CACHING`` env toggle (default ON).
+
+    Caching is behavior-neutral (identical outputs, lower cost), so it ships
+    on by default. Set ``AEP_PROMPT_CACHING`` to ``0``/``false``/``no``/``off``
+    to disable it if anything looks off. That path emits zero
+    ``cache_control`` markers, producing a byte-identical request to the
+    pre-caching behavior.
+    """
+    return os.environ.get("AEP_PROMPT_CACHING", "").strip().lower() not in _ENV_FALSE
+
+
+def _cache_usage(usage: Any) -> tuple[int, int]:
+    """Pull (cache_read, cache_creation) input tokens off an Anthropic usage.
+
+    The SDK reports these as ``None`` when caching is inactive, so coerce to 0.
+    """
+    read = getattr(usage, "cache_read_input_tokens", 0) or 0
+    creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
+    return read, creation
 
 
 def _extract_json_schema(response_format: dict[str, Any]) -> dict[str, Any] | None:
@@ -99,8 +129,17 @@ def _format_messages(
     return system_prompt, result
 
 
-def _tools_to_anthropic(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Convert OpenAI-format tools to Anthropic format."""
+def _tools_to_anthropic(
+    tools: list[dict[str, Any]], *, cache: bool = False
+) -> list[dict[str, Any]]:
+    """Convert OpenAI-format tools to Anthropic format.
+
+    When ``cache`` is True, a ``cache_control`` breakpoint is placed on the
+    final tool definition. Tool schemas render first in the Anthropic prompt,
+    so this caches the tool-definitions prefix (and covers the no-system-prompt
+    case, where the tools are the last static block). Freshly built dicts are
+    returned, so the caller's tool list is never mutated.
+    """
     result: list[dict[str, Any]] = []
     for tool in tools:
         if tool.get("type") == "function":
@@ -112,7 +151,23 @@ def _tools_to_anthropic(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     "input_schema": func.get("parameters", {"type": "object", "properties": {}}),
                 }
             )
+    if cache and result:
+        result[-1] = {**result[-1], "cache_control": dict(_CACHE_CONTROL)}
     return result
+
+
+def _system_param(system_prompt: str, *, cache: bool) -> str | list[dict[str, Any]]:
+    """Build the Anthropic ``system`` parameter.
+
+    Without caching, the plain string is returned (unchanged behavior). With
+    caching, the fully-assembled system text is wrapped in a single text block
+    carrying a ``cache_control`` breakpoint. System renders after tools, so
+    this block is the last static content and caches the tools+system prefix
+    together. The text is byte-identical either way, keeping outputs neutral.
+    """
+    if not cache:
+        return system_prompt
+    return [{"type": "text", "text": system_prompt, "cache_control": dict(_CACHE_CONTROL)}]
 
 
 class AnthropicClient:
@@ -125,6 +180,7 @@ class AnthropicClient:
         temperature: float = 0.7,
         max_tokens: int = 4096,
         supports_temperature: bool = True,
+        prompt_caching: bool | None = None,
     ) -> None:
         self._client = anthropic.AsyncAnthropic(api_key=api_key)
         self._model = model
@@ -136,6 +192,15 @@ class AnthropicClient:
         # caller drives this from the model catalog rather than a hardcoded
         # registry so new no-temperature models don't require an AEP release.
         self._supports_temperature = supports_temperature
+        # When True, ``cache_control`` breakpoints are attached to the static
+        # prefix (tool definitions + system prompt) so Anthropic can serve the
+        # repeated ~26k-token prefix from cache at ~0.1x input price instead of
+        # re-billing it every turn. Behavior-neutral: identical outputs, lower
+        # cost. Defaults to the ``AEP_PROMPT_CACHING`` env toggle (ON) so it can
+        # be disabled without an AEP release if anything looks off.
+        self._prompt_caching = (
+            _prompt_caching_default() if prompt_caching is None else prompt_caching
+        )
 
     @property
     def model_name(self) -> str:
@@ -161,12 +226,13 @@ class AnthropicClient:
         if self._supports_temperature:
             kwargs["temperature"] = temperature if temperature is not None else self._temperature
 
-        if system_prompt:
-            kwargs["system"] = system_prompt
-
         if tools:
-            kwargs["tools"] = _tools_to_anthropic(tools)
+            kwargs["tools"] = _tools_to_anthropic(tools, cache=self._prompt_caching)
 
+        # Assemble the complete system text (base prompt + any schema
+        # instruction) *before* attaching the cache_control breakpoint, so the
+        # breakpoint sits on the fully-assembled static block.
+        system_text = system_prompt
         if response_format:
             schema = _extract_json_schema(response_format)
             if schema:
@@ -175,12 +241,14 @@ class AnthropicClient:
                     f"```json\n{json.dumps(schema, indent=2)}\n```\n"
                     "Output ONLY the JSON object, no other text."
                 )
-                if "system" in kwargs:
-                    kwargs["system"] += f"\n\n{schema_prompt}"
-                else:
-                    kwargs["system"] = schema_prompt
+                system_text = f"{system_text}\n\n{schema_prompt}" if system_text else schema_prompt
+
+        if system_text:
+            kwargs["system"] = _system_param(system_text, cache=self._prompt_caching)
 
         response = await self._client.messages.create(**kwargs)
+
+        cache_read, cache_creation = _cache_usage(response.usage)
 
         # Extract text and tool calls
         text_parts: list[str] = []
@@ -202,6 +270,8 @@ class AnthropicClient:
             prompt_tokens=response.usage.input_tokens,
             completion_tokens=response.usage.output_tokens,
             total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
         )
 
         return ChatResponse(
@@ -235,15 +305,17 @@ class AnthropicClient:
             kwargs["temperature"] = temperature if temperature is not None else self._temperature
 
         if system_prompt:
-            kwargs["system"] = system_prompt
+            kwargs["system"] = _system_param(system_prompt, cache=self._prompt_caching)
 
         if tools:
-            kwargs["tools"] = _tools_to_anthropic(tools)
+            kwargs["tools"] = _tools_to_anthropic(tools, cache=self._prompt_caching)
 
         async with self._client.messages.stream(**kwargs) as stream:
             current_tool: dict[str, Any] | None = None
             input_tokens = 0
             output_tokens = 0
+            cache_read = 0
+            cache_creation = 0
             # If the stream closes with this still false, Anthropic
             # accepted the request and returned an SSE stream that
             # closed without emitting a single text, tool-call, or
@@ -257,6 +329,9 @@ class AnthropicClient:
                 if event.type == "message_start":
                     if hasattr(event.message, "usage"):
                         input_tokens = event.message.usage.input_tokens
+                        # Cache token counts are only reported on message_start
+                        # (message_delta carries output tokens only).
+                        cache_read, cache_creation = _cache_usage(event.message.usage)
 
                 elif event.type == "content_block_start":
                     if (
@@ -327,6 +402,8 @@ class AnthropicClient:
                                 prompt_tokens=input_tokens,
                                 completion_tokens=output_tokens,
                                 total_tokens=input_tokens + output_tokens,
+                                cache_read_input_tokens=cache_read,
+                                cache_creation_input_tokens=cache_creation,
                             ),
                         )
 

--- a/src/aceteam_aep/types.py
+++ b/src/aceteam_aep/types.py
@@ -45,17 +45,32 @@ class ChatMessage:
 
 @dataclass
 class Usage:
-    """Token usage statistics from an LLM call."""
+    """Token usage statistics from an LLM call.
+
+    ``cache_read_input_tokens`` and ``cache_creation_input_tokens`` surface
+    Anthropic prompt-caching activity so the host can log and bill it. When a
+    provider or model returns no caching data both stay 0, and
+    ``prompt_tokens`` retains its prior meaning (the provider's reported input
+    token count). Note that when caching is active on Anthropic,
+    ``prompt_tokens`` is the *uncached* remainder; the full prompt size is
+    ``prompt_tokens + cache_read_input_tokens + cache_creation_input_tokens``.
+    """
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
 
     def __add__(self, other: Usage) -> Usage:
         return Usage(
             prompt_tokens=self.prompt_tokens + other.prompt_tokens,
             completion_tokens=self.completion_tokens + other.completion_tokens,
             total_tokens=self.total_tokens + other.total_tokens,
+            cache_read_input_tokens=self.cache_read_input_tokens + other.cache_read_input_tokens,
+            cache_creation_input_tokens=(
+                self.cache_creation_input_tokens + other.cache_creation_input_tokens
+            ),
         )
 
 

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -11,6 +11,7 @@ import pytest
 from aceteam_aep import create_client
 from aceteam_aep.providers import StreamFailedError
 from aceteam_aep.providers.anthropic import AnthropicClient
+from aceteam_aep.types import ChatMessage, Usage
 
 
 class _FakeAsyncStream:
@@ -64,6 +65,21 @@ def _finish_event(stop_reason: str = "end_turn") -> MagicMock:
     event.delta.stop_reason = stop_reason
     event.usage = MagicMock()
     event.usage.output_tokens = 12
+    return event
+
+
+def _message_start_event(
+    input_tokens: int = 3,
+    cache_read: int | None = 0,
+    cache_creation: int | None = 0,
+) -> MagicMock:
+    event = MagicMock()
+    event.type = "message_start"
+    event.message = MagicMock()
+    event.message.usage = MagicMock()
+    event.message.usage.input_tokens = input_tokens
+    event.message.usage.cache_read_input_tokens = cache_read
+    event.message.usage.cache_creation_input_tokens = cache_creation
     return event
 
 
@@ -189,6 +205,8 @@ def _make_nonstream_response() -> MagicMock:
     response.usage = MagicMock()
     response.usage.input_tokens = 3
     response.usage.output_tokens = 5
+    response.usage.cache_read_input_tokens = 0
+    response.usage.cache_creation_input_tokens = 0
     response.model = "claude-opus-4-8"
     response.stop_reason = "end_turn"
     return response
@@ -251,3 +269,212 @@ async def test_chat_stream_includes_temperature_by_default() -> None:
         pass
 
     assert "temperature" in stream_mock.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Prompt caching: request shaping. cache_control breakpoints must land on the
+# static prefix (tool definitions + system prompt) so Anthropic serves the
+# repeated ~26k-token prefix from cache. Behavior-neutral: the text is
+# byte-identical whether or not the breakpoints are present.
+# ---------------------------------------------------------------------------
+
+_OPENAI_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "search the web",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calc",
+            "description": "do math",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+
+def _make_chat_client(*, prompt_caching: bool | None) -> tuple[AnthropicClient, AsyncMock]:
+    client = AnthropicClient(api_key="test", model="claude-opus-4-8", prompt_caching=prompt_caching)
+    create_mock = AsyncMock(return_value=_make_nonstream_response())
+    client._client = MagicMock()
+    client._client.messages.create = create_mock
+    return client, create_mock
+
+
+@pytest.mark.asyncio
+async def test_chat_caches_system_and_last_tool_when_enabled() -> None:
+    client, create_mock = _make_chat_client(prompt_caching=True)
+
+    await client.chat(
+        messages=[ChatMessage(role="system", content="You are helpful."),
+                  ChatMessage(role="user", content="hi")],
+        tools=_OPENAI_TOOLS,
+    )
+
+    kwargs = create_mock.call_args.kwargs
+    # System becomes a block list with a cache_control breakpoint on the block.
+    system = kwargs["system"]
+    assert isinstance(system, list)
+    assert system[0]["text"] == "You are helpful."
+    assert system[-1]["cache_control"] == {"type": "ephemeral"}
+    # Only the last tool carries a breakpoint; earlier tools do not.
+    tools = kwargs["tools"]
+    assert "cache_control" not in tools[0]
+    assert tools[-1]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_chat_no_cache_control_when_disabled() -> None:
+    client, create_mock = _make_chat_client(prompt_caching=False)
+
+    await client.chat(
+        messages=[ChatMessage(role="system", content="You are helpful."),
+                  ChatMessage(role="user", content="hi")],
+        tools=_OPENAI_TOOLS,
+    )
+
+    kwargs = create_mock.call_args.kwargs
+    # Disabled path is a byte-identical revert: plain string system, no markers.
+    assert kwargs["system"] == "You are helpful."
+    assert all("cache_control" not in tool for tool in kwargs["tools"])
+
+
+@pytest.mark.asyncio
+async def test_chat_caches_last_tool_without_system_prompt() -> None:
+    client, create_mock = _make_chat_client(prompt_caching=True)
+
+    await client.chat(messages=[ChatMessage(role="user", content="hi")], tools=_OPENAI_TOOLS)
+
+    kwargs = create_mock.call_args.kwargs
+    # No system prompt: the tools are the last static block, so they carry the
+    # breakpoint and no system param is sent.
+    assert "system" not in kwargs
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_chat_cache_control_wraps_full_system_with_schema() -> None:
+    client, create_mock = _make_chat_client(prompt_caching=True)
+
+    await client.chat(
+        messages=[ChatMessage(role="system", content="Base prompt."),
+                  ChatMessage(role="user", content="hi")],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"schema": {"type": "object", "properties": {"x": {"type": "string"}}}},
+        },
+    )
+
+    system = create_mock.call_args.kwargs["system"]
+    # A single block holds base prompt + schema instruction, and the breakpoint
+    # sits on that fully-assembled block (not before the schema append).
+    assert isinstance(system, list)
+    assert len(system) == 1
+    assert system[0]["text"].startswith("Base prompt.")
+    assert "valid JSON object" in system[0]["text"]
+    assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_env_toggle_disables_caching(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AEP_PROMPT_CACHING", "0")
+    # prompt_caching=None → env toggle decides.
+    client, create_mock = _make_chat_client(prompt_caching=None)
+
+    await client.chat(
+        messages=[ChatMessage(role="system", content="You are helpful.")],
+        tools=_OPENAI_TOOLS,
+    )
+
+    assert create_mock.call_args.kwargs["system"] == "You are helpful."
+    assert all("cache_control" not in tool for tool in create_mock.call_args.kwargs["tools"])
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_shapes_cache_control_when_enabled() -> None:
+    client = AnthropicClient(api_key="test", model="claude-opus-4-8", prompt_caching=True)
+    stream_mock = MagicMock(
+        return_value=_FakeAsyncStream([_message_start_event(), _finish_event()])
+    )
+    client._client = MagicMock()
+    client._client.messages.stream = stream_mock
+
+    async for _ in client.chat_stream(
+        messages=[ChatMessage(role="system", content="You are helpful.")],
+        tools=_OPENAI_TOOLS,
+    ):
+        pass
+
+    kwargs = stream_mock.call_args.kwargs
+    assert kwargs["system"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+# ---------------------------------------------------------------------------
+# Prompt caching: usage propagation. cache_read/cache_creation must surface
+# on Usage so the host app can log and bill them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_propagates_cache_usage() -> None:
+    client, create_mock = _make_chat_client(prompt_caching=True)
+    response = _make_nonstream_response()
+    response.usage.cache_read_input_tokens = 24000
+    response.usage.cache_creation_input_tokens = 100
+    create_mock.return_value = response
+
+    result = await client.chat(messages=[ChatMessage(role="user", content="hi")])
+
+    assert result.usage.cache_read_input_tokens == 24000
+    assert result.usage.cache_creation_input_tokens == 100
+    # prompt_tokens keeps its prior meaning (the uncached remainder Anthropic
+    # reports as input_tokens); cache fields are additive.
+    assert result.usage.prompt_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_chat_cache_usage_defaults_zero_when_absent() -> None:
+    client, create_mock = _make_chat_client(prompt_caching=True)
+    response = _make_nonstream_response()
+    # SDK reports None when caching is inactive; must coerce to 0.
+    response.usage.cache_read_input_tokens = None
+    response.usage.cache_creation_input_tokens = None
+    create_mock.return_value = response
+
+    result = await client.chat(messages=[ChatMessage(role="user", content="hi")])
+
+    assert result.usage.cache_read_input_tokens == 0
+    assert result.usage.cache_creation_input_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_propagates_cache_usage() -> None:
+    client = AnthropicClient(api_key="test", model="claude-opus-4-8", prompt_caching=True)
+    stream_mock = MagicMock(
+        return_value=_FakeAsyncStream(
+            [_message_start_event(cache_read=24000, cache_creation=100), _finish_event()]
+        )
+    )
+    client._client = MagicMock()
+    client._client.messages.stream = stream_mock
+
+    usages = [c.usage async for c in client.chat_stream(messages=[]) if c.usage]
+
+    assert usages, "expected a usage-bearing chunk"
+    assert usages[-1].cache_read_input_tokens == 24000
+    assert usages[-1].cache_creation_input_tokens == 100
+
+
+def test_usage_add_sums_cache_fields() -> None:
+    # Aggregation across an agent loop (agent.py does total += call_usage) must
+    # carry the cache fields, not drop them.
+    total = Usage() + Usage(cache_read_input_tokens=10, cache_creation_input_tokens=2)
+    total = total + Usage(cache_read_input_tokens=5, cache_creation_input_tokens=3)
+    assert total.cache_read_input_tokens == 15
+    assert total.cache_creation_input_tokens == 5

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -34,6 +34,18 @@ TEST_RESPONSE_FORMAT = {
 TEST_MESSAGES = [ChatMessage(role="user", content="Extract the data")]
 
 
+def _system_text(system) -> str:
+    """Extract the system text regardless of shape.
+
+    With Anthropic prompt caching enabled (the default), the ``system`` param
+    is a list of text blocks carrying a ``cache_control`` breakpoint; without
+    it, it's a plain string. Both forms hold identical text.
+    """
+    if isinstance(system, str):
+        return system
+    return "".join(block.get("text", "") for block in system)
+
+
 class TestOpenAIResponseFormat:
     """OpenAI provider passes response_format directly to the API."""
 
@@ -124,7 +136,7 @@ class TestAnthropicResponseFormat:
             call_kwargs = mock_client.messages.create.call_args
             # Schema should be in the system prompt
             assert "system" in call_kwargs.kwargs
-            system = call_kwargs.kwargs["system"]
+            system = _system_text(call_kwargs.kwargs["system"])
             assert "first_name" in system
             assert "school" in system
             assert "major" in system
@@ -154,7 +166,7 @@ class TestAnthropicResponseFormat:
             await client.chat(messages, response_format=TEST_RESPONSE_FORMAT)
 
             call_kwargs = mock_client.messages.create.call_args
-            system = call_kwargs.kwargs["system"]
+            system = _system_text(call_kwargs.kwargs["system"])
             # Should contain BOTH the original system prompt and the schema
             assert "data extractor" in system
             assert "first_name" in system


### PR DESCRIPTION
## Context

aceteam PR [#5901](https://github.com/aceteam-ai/aceteam/pull/5901) pulled the real `model_usage_stats` rows for a single "build me a teaching assistant" turn and proved, from prod, that agent calls run with `cache_read_tokens = 0` and `cache_write_tokens = 0` on **every** call:

| Call | input_tokens | output_tokens | cache_read | cache_write |
| ---- | -----------: | ------------: | ---------: | ----------: |
| 1 | 26,342 | 47 | 0 | 0 |
| 2 | 121,690 | 2,486 | 0 | 0 |

That ~26k-token static prefix (system prompt + 72 tool schemas) is re-billed at full input price on every round-trip. The agent loop and Anthropic provider live in this package (`aceteam-aep`), not in the aceteam repo, so #5901 flagged prompt caching as the highest-leverage follow-up but could not fix it there. This PR is that fix. Fixes context for aceteam-ai/aceteam#5856.

Prompt caching is a prefix match: the same static prefix, served from cache, costs ~0.1x input price on the second and later calls. For chat / agent-builder turns that re-send the same system prompt + tool schemas every step, this is the single biggest cost lever.

## Summary

**Request shaping (`providers/anthropic.py`)** — attach `cache_control: {"type": "ephemeral"}` breakpoints to the static prefix:

- **Last tool definition** gets a breakpoint (`_tools_to_anthropic(..., cache=True)`, on the fresh dicts it already builds, so the caller's list is never mutated). Tool schemas render first in the Anthropic prompt, so this caches the tools-only prefix and covers the no-system-prompt case where the tools are the last static block.
- **System prompt** is wrapped in a single text block with a breakpoint (`_system_param`). System renders after tools, so this block is the last static content and caches the tools+system prefix together. The text is byte-identical to the plain-string form, so outputs are unchanged.
- The `response_format` schema instruction is folded into the system text **before** the breakpoint is attached, so the cached block is the fully-assembled static content (not a pre-schema fragment). This was also a latent bug magnet: the old `kwargs["system"] += schema_prompt` string concat would have broken the moment `system` became a block list.
- Applied on both `chat()` and `chat_stream()`.
- No min-length gate: sub-threshold prefixes silently don't cache (no error), so unconditional markers stay behavior-neutral.

**Usage propagation (`types.py`, `providers/anthropic.py`)** — `Usage` gains `cache_read_input_tokens` and `cache_creation_input_tokens` (default 0, summed in `__add__` so agent-loop aggregation carries them). Populated from `response.usage` on the non-streaming path and from the `message_start` event on the streaming path (that is where Anthropic reports cache tokens; `message_delta` carries output only), coercing the SDK's `None` to 0. `prompt_tokens` keeps its prior meaning (Anthropic's `input_tokens`, i.e. the uncached remainder once caching is live) so existing consumers are unaffected; the cache fields are additive, matching the #5901 usage table layout (total = input + output; cache_read / cache_write as separate columns).

**Configurable, default ON (`factory.py`)** — `prompt_caching` param on `AnthropicClient` and `create_client()`, defaulting to the `AEP_PROMPT_CACHING` env toggle (ON unless set to `0`/`false`/`no`/`off`). When disabled, **zero** `cache_control` markers are emitted, so "disable if anything looks off" is a byte-identical revert of the request shape.

### Notes / scope

- **Internal cost tree under-counts once caching is live.** `costs.py` bills `input_rate * prompt_tokens` and does not yet apply the ~0.1x read / ~1.25x write rates for the cache columns, so its numbers drift slightly low. This is acceptable because authoritative billing is host-side; flagging it explicitly rather than letting it drift silently.
- **Host-side wiring is a separate aceteam-repo change.** #5901 notes the agent path currently passes 0 for `cache_read_tokens` / `cache_write_tokens` into `log_model_usage`. This PR only *exposes* the fields on `Usage`; mapping them into `model_usage_stats` is the follow-up on the aceteam side.
- **Out of scope (deliberately):** growing-conversation-history caching (the `messages[-1]` breakpoint pattern). Real additional win, but the ask here is the static prefix; can be a follow-up.

## Test plan

All new tests are in `tests/test_providers/test_anthropic.py` (pure request-shaping + usage assertions, no live API).

| Group | Coverage |
| ----- | -------- |
| Request shaping | cache_control on last tool + system block when enabled; only the last tool (not earlier ones) carries it; no markers when disabled (byte-identical revert); last-tool-cached with no system prompt; full assembled system+schema wrapped in one block with the breakpoint; `AEP_PROMPT_CACHING=0` disables via env; streaming path shapes cache_control the same way |
| Usage propagation | `chat()` propagates cache_read/cache_creation from `response.usage`; `None` coerces to 0; `chat_stream()` propagates from `message_start`; `Usage.__add__` sums the cache fields (agent-loop aggregation path) |
| Regression | Updated two existing `test_structured_output.py` assertions that assumed `system` is a plain string, via a shape-agnostic `_system_text()` helper (the schema-injection behavior itself is unchanged) |

Targeted suites green: `test_anthropic` (19 new + existing), `test_structured_output`, `test_types`, `test_costs`, `test_agent`, `test_models`, `test_config` (57 in the anthropic+structured+consumers set, all pass). `ruff check` clean on all changed files; `pyright` adds zero new errors (the 8 pre-existing streaming-delta duck-typing errors are unchanged, just shifted line numbers). The full `pytest` run hangs on unrelated proxy/dashboard integration tests that need live services, so verification was done on the relevant subset.

## Related

- Follow-up to aceteam-ai/aceteam PR #5901 (proved cache_read/write = 0 from prod)
- Fixes context for aceteam-ai/aceteam#5856

---
*Generated by Claude Opus 4.8*