### PR TITLE
fix: cache safety detector pipelines at module level (#122)

### DIFF
--- a/src/aceteam_aep/safety/content.py
+++ b/src/aceteam_aep/safety/content.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Sequence
 
 from .base import SafetyDetector, SafetySignal
 
 log = logging.getLogger(__name__)
+
+# The transformers pipeline is an immutable, read-only artifact — ``check()`` only
+# runs inference. Cache it at module level, keyed by model name, so per-session
+# detector instances share one in-memory copy instead of each rebuilding the model.
+_PIPELINE_CACHE: dict[str, object] = {}
+_PIPELINE_LOCK = threading.Lock()
 
 
 class ContentSafetyDetector(SafetyDetector):
@@ -32,20 +39,26 @@ class ContentSafetyDetector(SafetyDetector):
 
     def _load(self) -> None:
         self._load_attempted = True
-        try:
-            from transformers import pipeline
+        with _PIPELINE_LOCK:
+            cached = _PIPELINE_CACHE.get(self._model_name)
+            if cached is not None:
+                self._pipeline = cached
+                return
+            try:
+                from transformers import pipeline
 
-            self._pipeline = pipeline(
-                "text-classification",
-                model=self._model_name,
-                device=-1,
-            )
-        except ImportError:
-            log.warning("transformers not installed, content safety detector disabled")
-            self._available = False
-        except Exception:
-            log.warning("Content safety model unavailable", exc_info=True)
-            self._available = False
+                self._pipeline = pipeline(
+                    "text-classification",
+                    model=self._model_name,
+                    device=-1,
+                )
+                _PIPELINE_CACHE[self._model_name] = self._pipeline
+            except ImportError:
+                log.warning("transformers not installed, content safety detector disabled")
+                self._available = False
+            except Exception:
+                log.warning("Content safety model unavailable", exc_info=True)
+                self._available = False
 
     async def check(
         self,

--- a/src/aceteam_aep/safety/pii.py
+++ b/src/aceteam_aep/safety/pii.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 from .base import SafetyDetector, SafetySignal
 
 log = logging.getLogger(__name__)
+
+# The transformers pipeline is an immutable, read-only artifact — ``check()`` only
+# runs inference. Cache it at module level, keyed by model name, so per-session
+# detector instances share one in-memory copy instead of each rebuilding the model.
+_PIPELINE_CACHE: dict[str, object] = {}
+_PIPELINE_LOCK = threading.Lock()
 
 _PII_ENTITIES = {
     "SSN",
@@ -85,25 +92,32 @@ class PiiDetector(SafetyDetector):
 
     def _load(self) -> None:
         self._load_attempted = True
-        try:
-            from transformers import pipeline
+        with _PIPELINE_LOCK:
+            cached = _PIPELINE_CACHE.get(self._model_name)
+            if cached is not None:
+                self._pipeline = cached
+                return
+            try:
+                from transformers import pipeline
 
-            self._pipeline = pipeline(
-                "token-classification",
-                model=self._model_name,
-                aggregation_strategy="simple",
-                device=-1,
-            )
-        except ImportError:
-            log.warning("transformers not installed, PII detector falling back to regex")
-            self._fallback = True
-        except Exception:
-            log.warning(
-                "Failed to load PII model %s, falling back to regex",
-                self._model_name,
-                exc_info=True,
-            )
-            self._fallback = True
+                self._pipeline = pipeline(
+                    "token-classification",
+                    model=self._model_name,
+                    aggregation_strategy="simple",
+                    device=-1,
+                )
+                _PIPELINE_CACHE[self._model_name] = self._pipeline
+                return
+            except ImportError:
+                log.warning("transformers not installed, PII detector falling back to regex")
+                self._fallback = True
+            except Exception:
+                log.warning(
+                    "Failed to load PII model %s, falling back to regex",
+                    self._model_name,
+                    exc_info=True,
+                )
+                self._fallback = True
 
     async def check(
         self,

--- a/tests/test_safety/test_pii.py
+++ b/tests/test_safety/test_pii.py
@@ -49,6 +49,23 @@ async def test_detects_phone_number(detector: PiiDetector) -> None:
     assert any(s.signal_type == "pii" for s in signals)
 
 
+def test_pipeline_shared_across_instances() -> None:
+    """Two detectors for the same model share one cached pipeline (no rebuild)."""
+    from aceteam_aep.safety import pii
+
+    if "transformers" not in __import__("sys").modules:
+        pytest.importorskip("transformers")
+
+    d1 = PiiDetector()
+    d1._load()
+    if d1._fallback:
+        pytest.skip("model unavailable, cache not exercised")
+    d2 = PiiDetector()
+    d2._load()
+    assert d1._pipeline is d2._pipeline
+    assert pii._PIPELINE_CACHE[d1._model_name] is d1._pipeline
+
+
 async def test_regex_fallback_works() -> None:
     """Force regex fallback and verify it works."""
     det = PiiDetector(model_name="nonexistent/model-that-will-fail")


### PR DESCRIPTION
Closes #122.

## Problem

`PiiDetector` and `ContentSafetyDetector` held their transformers pipeline as **instance** state with no shared cache, so every detector instance re-materialized the immutable model into memory. The model is read-only and `check()` only runs inference, so this was pure waste — paid on every construction.

Consumers that build detectors per session (reasonable, since `ProxyState` owns genuinely-mutable per-session state) rebuilt the model each time, and a process holding N sessions pinned N duplicate copies of identical weights (~489 MB for three `ContentSafetyDetector` instances). Test suites that reset per-session proxy state paid the model cost per test.

## Fix

Cache the built pipeline at module level, keyed by model name, in both `pii.py` and `content.py`:

- `_load()` checks the cache first and returns the shared pipeline on a hit.
- On a miss it builds the pipeline once and stores it, under a `threading.Lock` so concurrent first-loads don't each build a copy (detail #1 in the issue).
- Only the immutable pipeline is shared; per-instance `_fallback`/`_available`/`_load_attempted` stay per-instance.

Left out the injectable-pipeline-factory seam (detail 2) — optional and no downstream code needs it yet. Happy to fold in on request.

## Verification

- `ruff check` — clean
- `pyright` on both files — 0 errors
- `pytest tests/test_safety/` — passing, plus a new `test_pipeline_shared_across_instances` asserting two instances share one cached pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)