### PR TITLE
fix(costs): report full cost totals and keep per-span sums in Decimal

### DIFF
--- a/src/aceteam_aep/mcp_gateway.py
+++ b/src/aceteam_aep/mcp_gateway.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 log = logging.getLogger(__name__)
@@ -169,21 +170,25 @@ def create_mcp_app(state: ProxyState) -> ASGIApp | None:
         Returns total cost, per-call costs, and cost by model.
         """
         costs = state._call_costs
-        total = float(state.cost_usd)
+        total = state.cost_usd
 
-        # Build per-model breakdown from spans
-        model_costs: dict[str, float] = {}
+        # Build per-model breakdown from spans. span.cost is a CostNode, not a
+        # number — accumulate its Decimal total and convert once at the end.
+        model_totals: dict[str, Decimal] = {}
         for span in state.span_tracker.get_spans():
             model = span.executor_id or "unknown"
-            cost = float(span.cost) if hasattr(span, "cost") and span.cost else 0.0
-            model_costs[model] = model_costs.get(model, 0.0) + cost
+            cost = span.cost.total_cost() if span.cost else Decimal("0")
+            model_totals[model] = model_totals.get(model, Decimal("0")) + cost
+        model_costs = {model: float(subtotal) for model, subtotal in model_totals.items()}
+
+        savings = state.blocked_count * (total / max(state.call_count, 1))
 
         return json.dumps(
             {
-                "total_cost_usd": total,
+                "total_cost_usd": float(total),
                 "total_calls": state.call_count,
                 "blocked_calls": state.blocked_count,
-                "savings_from_blocks": f"${state.blocked_count * (total / max(state.call_count, 1)):.4f}",
+                "savings_from_blocks": f"${savings:.4f}",
                 "cost_per_call": [float(c) for c in costs[-10:]],  # last 10
                 "cost_by_model": model_costs,
             },

--- a/src/aceteam_aep/proxy/app.py
+++ b/src/aceteam_aep/proxy/app.py
@@ -319,13 +319,17 @@ class ProxyState:
         return avg * self.blocked_count
 
     def _cost_by_span_id(self) -> dict[str, float]:
-        """Build a lookup of span_id → cost in USD."""
-        lookup: dict[str, float] = {}
+        """Build a lookup of span_id → cost in USD.
+
+        Accumulate in Decimal and convert once at the end: a span can own several
+        cost nodes, and summing them as floats lets rounding error compound.
+        """
+        totals: dict[str, Decimal] = {}
         for node in self.cost_tracker.get_cost_tree():
             sid = node.metadata.get("span_id")
             if sid:
-                lookup[sid] = lookup.get(sid, 0.0) + float(node.compute_cost)
-        return lookup
+                totals[sid] = totals.get(sid, Decimal("0")) + node.total_cost()
+        return {sid: float(total) for sid, total in totals.items()}
 
     def to_dict(self) -> dict[str, Any]:
         """State as JSON-serializable dict for the dashboard."""
@@ -761,7 +765,7 @@ def create_proxy_app(
                     model=model,
                     usage=usage,
                 )
-                state._call_costs.append(cost_node.compute_cost)
+                state._call_costs.append(cost_node.total_cost())
                 state.span_tracker.end_span(stream_span.span_id)
                 state.call_count += 1
                 state.signals.extend(signals)
@@ -781,7 +785,7 @@ def create_proxy_app(
                                 action=decision.action,
                                 message=decision.reason
                                 or f"{model} streaming call: {inp} in, {out} out",
-                                cost_usd=float(cost_node.compute_cost) if cost_node else 0,
+                                cost_usd=float(cost_node.total_cost()) if cost_node else 0,
                                 model=model,
                                 tokens_in=inp,
                                 tokens_out=out,
@@ -835,7 +839,7 @@ def create_proxy_app(
                                 provider=_detect_provider(state.target_base_url),
                                 tokens_in=inp,
                                 tokens_out=out,
-                                cost_usd=float(cost_node.compute_cost),
+                                cost_usd=float(cost_node.total_cost()),
                                 latency_ms=stream_span.duration_ms,
                             )
                         )
@@ -932,7 +936,7 @@ def create_proxy_app(
             model=model,
             usage=usage,
         )
-        state._call_costs.append(cost_node.compute_cost)
+        state._call_costs.append(cost_node.total_cost())
         state.span_tracker.end_span(span.span_id)
         state.call_count += 1
 
@@ -942,7 +946,7 @@ def create_proxy_app(
                 input_text=input_text,
                 output_text=output_text,
                 call_id=call_id,
-                call_cost=cost_node.compute_cost,
+                call_cost=cost_node.total_cost(),
             )
 
             # Emit safety_signal events for output signals
@@ -996,7 +1000,7 @@ def create_proxy_app(
                             provider=_detect_provider(state.target_base_url),
                             tokens_in=input_tokens,
                             tokens_out=output_tokens,
-                            cost_usd=float(cost_node.compute_cost),
+                            cost_usd=float(cost_node.total_cost()),
                             latency_ms=span.duration_ms,
                         )
                     )
@@ -1061,7 +1065,7 @@ def create_proxy_app(
                             provider=_detect_provider(state.target_base_url),
                             tokens_in=input_tokens,
                             tokens_out=output_tokens,
-                            cost_usd=float(cost_node.compute_cost),
+                            cost_usd=float(cost_node.total_cost()),
                             latency_ms=span.duration_ms,
                         )
                     )
@@ -1080,7 +1084,7 @@ def create_proxy_app(
                     action=decision.action,
                     message=decision.reason
                     or f"{model} call: {input_tokens} in, {output_tokens} out",
-                    cost_usd=float(cost_node.compute_cost) if cost_node else 0,
+                    cost_usd=float(cost_node.total_cost()) if cost_node else 0,
                     model=model,
                     tokens_in=input_tokens if usage else None,
                     tokens_out=output_tokens if usage else None,
@@ -1091,7 +1095,7 @@ def create_proxy_app(
 
         # --- PASS THROUGH (with AEP metadata header) ---
         resp_headers = build_response_headers(
-            cost=cost_node.compute_cost,
+            cost=cost_node.total_cost(),
             enforcement=decision.action,
             call_id=call_id,
             classification=aep_ctx.classification,

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -15,10 +15,10 @@ def _parse_sse_json(resp):
     return None
 
 
-def _init_mcp_session(client):
+def _init_mcp_session(client, path="/mcp/mcp/"):
     """Initialize an MCP session and return (session_headers, init_data)."""
     resp = client.post(
-        "/mcp/mcp/",
+        path,
         json={
             "jsonrpc": "2.0",
             "id": 1,
@@ -39,7 +39,7 @@ def _init_mcp_session(client):
 
     # Send initialized notification
     client.post(
-        "/mcp/mcp/",
+        path,
         json={
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
@@ -331,3 +331,52 @@ def test_mcp_set_policy_with_detectors():
         detectors = result.get("policy", {}).get("detectors", {})
         assert detectors.get("pii", {}).get("enabled") is False
         assert detectors.get("agent_threat", {}).get("action") == "block"
+
+
+def test_mcp_get_cost_summary_with_span_costs():
+    """get_cost_summary must handle spans that carry a CostNode.
+
+    span.cost is a CostNode, not a number. The per-model breakdown used to call
+    float() on it directly, which raised TypeError — but only once a span
+    actually had a cost attached, so an empty session hid the bug.
+    """
+    import json as _json
+    from decimal import Decimal
+
+    from starlette.testclient import TestClient
+
+    from aceteam_aep.costs import CostNode
+    from aceteam_aep.mcp_gateway import create_mcp_app
+    from aceteam_aep.proxy.app import ProxyState
+
+    state = ProxyState()
+    span = state.span_tracker.start_span(executor_type="llm", executor_id="gpt-4o")
+    span.cost = CostNode(
+        id="n1",
+        parent_id=None,
+        entity="gpt-4o",
+        category="llm",
+        compute_cost=Decimal("0.10"),
+        value_added_fee=Decimal("0.02"),
+        platform_fee=Decimal("0.01"),
+    )
+
+    with TestClient(create_mcp_app(state)) as client:
+        headers, _ = _init_mcp_session(client, path="/mcp/")
+        resp = client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {"name": "get_cost_summary", "arguments": {}},
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = _parse_sse_json(resp)
+        content = data.get("result", {}).get("content", [{}])[0].get("text", "")
+        result = _json.loads(content)
+
+        # Fees count toward the reported cost, not compute_cost alone.
+        assert result["cost_by_model"]["gpt-4o"] == 0.13

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -285,3 +286,35 @@ class TestProxyDashboard:
         data = resp.json()
         assert "cost" in data
         assert "calls" in data
+
+
+class TestCostAggregation:
+    """Per-span cost totals must include fees and stay in Decimal while summing."""
+
+    def _state_with_two_nodes(self):
+        from aceteam_aep.proxy.app import ProxyState
+        from aceteam_aep.types import Usage
+
+        state = ProxyState()
+        for _ in range(2):
+            node = state.cost_tracker.record_llm_cost(
+                span_id="span-1",
+                model="gpt-4o",
+                usage=Usage(prompt_tokens=1000, completion_tokens=1000, total_tokens=2000),
+            )
+            node.value_added_fee = Decimal("0.01")
+            node.platform_fee = Decimal("0.02")
+        return state
+
+    def test_span_cost_includes_fees_and_matches_decimal_sum(self) -> None:
+        state = self._state_with_two_nodes()
+        nodes = state.cost_tracker.get_cost_tree()
+        expected = sum((n.total_cost() for n in nodes), Decimal("0"))
+        compute_only = sum((n.compute_cost for n in nodes), Decimal("0"))
+
+        lookup = state._cost_by_span_id()
+
+        # Exact: the sum happens in Decimal, with a single conversion at the end.
+        assert lookup["span-1"] == float(expected)
+        # compute_cost alone would omit the 0.06 of fees across both nodes.
+        assert lookup["span-1"] != float(compute_only)


### PR DESCRIPTION
Follow-up to the v0.11.6 release. While triaging pyright's 142 errors, one turned out to be a live crash — and pulling on it surfaced two more problems in the same area.

## 1. `get_cost_summary` raises `TypeError` (crash)

`mcp_gateway.py` did:

```python
cost = float(span.cost) if hasattr(span, "cost") and span.cost else 0.0
```

`Span.cost` is a `CostNode` dataclass (`spans.py:26`), not a number:

```
TypeError: float() argument must be a string or a real number, not 'CostNode'
```

The `and span.cost` guard means it only fires once a span *actually has a cost attached* — so the tool works on an empty session and breaks in real use. That's why the existing `test_mcp_get_cost_summary` never caught it.

## 2. Fees dropped from every reported cost

`CostNode` is `compute_cost + value_added_fee + platform_fee`, and `total_cost()` exists to combine them. Eight sites read the raw `compute_cost` field instead:

- `proxy/app.py:734, 762, 886, 926, 942` — `cost_usd` on every emitted observability event
- `proxy/app.py:322-328` — the per-span dashboard lookup
- `proxy/app.py:714, 848` — `_call_costs`, which feeds `estimated_savings` and `avg_call_cost_usd`

So the dashboard, the audit events, and the savings estimate understate cost, while `check_budget` enforces against the full amount — the two disagree. `agent.py:299` and `envelope_helpers.py:18` already use `total_cost()`; this brings the rest in line.

## 3. A float accumulator

`_cost_by_span_id` converted each node to `float` and *then* accumulated:

```python
lookup[sid] = lookup.get(sid, 0.0) + float(node.compute_cost)
```

Not a boundary conversion — a span can own several nodes, so rounding error compounds. Now sums in `Decimal` and converts once at the end, per the project's Decimal-for-money convention. Budget enforcement itself was already Decimal-clean throughout.

## Tests

Two regression tests, both verified to fail on the previous code — the MCP one with the actual `TypeError`, the aggregation one on the dropped fees. Full suite: **630 passed, 15 skipped**.

## Notes

- **No released number changes.** `value_added_fee` / `platform_fee` are never set outside `costs.py` today, so this is latent until someone populates a fee.
- No unrelated reformatting — `ruff format` wants to reformat much of `app.py` and `test_proxy.py`, and I deliberately left that out. The 6 remaining `E501`s in `app.py` pre-exist on `main`.

## Still open (not in this PR)

- `ObservabilityEvent.cost_usd` is typed `float` (`observability/events.py:32`), so cost is stored as float in the sqlite audit store — for a signed-audit product that bakes rounding into a durable record. Storing the `Decimal` as a string or integer microdollars would preserve it, but it's a schema migration.
- There is still no CI workflow running pytest/ruff/pyright — `.github/workflows/` only publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)